### PR TITLE
Adds CI for new providers

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -50,4 +50,8 @@ phases:
       - cd aws-logs-subscriptionfilter
       - mvn clean verify --no-transfer-progress
     finally:
-      - cat rpdk.log
+      - cat "$CODEBUILD_SRC_DIR/aws-logs-destination/rpdk.log"
+      - cat "$CODEBUILD_SRC_DIR/aws-logs-loggroup/rpdk.log"
+      - cat "$CODEBUILD_SRC_DIR/aws-logs-logstream/rpdk.log"
+      - cat "$CODEBUILD_SRC_DIR/aws-logs-metricfilter/rpdk.log"
+      - cat "$CODEBUILD_SRC_DIR/aws-logs-subscriptionfilter/rpdk.log"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

buildspec.yml had not been updated to include CI coverage for;
* `AWS::Logs::Destination`
* `AWS::Logs::LogGroup`
* `AWS::Logs::LogStream`
* `AWS::Logs::SubscriptionFilter`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
