### PR TITLE
Use static HTTP client so less memory is consumed

### DIFF
--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -21,16 +21,16 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://central.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 
     <dependencies>
-        <!-- https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/ -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.5.56</version>
+            <version>2.10.19</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->

--- a/aws-logs-loggroup/resource-role.yaml
+++ b/aws-logs-loggroup/resource-role.yaml
@@ -23,11 +23,11 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - "logs:DescribeLogGroups"
                 - "logs:CreateLogGroup"
-                - "logs:DeleteRetentionPolicy"
-                - "logs:PutRetentionPolicy"
                 - "logs:DeleteLogGroup"
+                - "logs:DeleteRetentionPolicy"
+                - "logs:DescribeLogGroups"
+                - "logs:PutRetentionPolicy"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ClientBuilder.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ClientBuilder.java
@@ -1,10 +1,14 @@
 package software.amazon.logs.loggroup;
 
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
+    private ClientBuilder() {}
+
     public static CloudWatchLogsClient getClient() {
         return CloudWatchLogsClient.builder()
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
                 .build();
     }
 }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -6,7 +6,6 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolic
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
-import software.amazon.logs.loggroup.ResourceModel;
 
 import java.util.Collection;
 import java.util.List;

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
@@ -7,8 +7,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.logs.loggroup.BaseHandler;
-import software.amazon.logs.loggroup.ResourceModel;
 
 import java.util.Objects;
 

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
@@ -18,7 +18,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceAlreadyExistsException;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,7 +44,7 @@ public class CreateHandlerTest {
     @Test
     public void handleRequest_Success() {
         final DescribeLogGroupsResponse describeResponseInitial = DescribeLogGroupsResponse.builder()
-                .logGroups(Arrays.asList())
+                .logGroups(Collections.emptyList())
                 .build();
         final CreateLogGroupResponse createLogGroupResponse = CreateLogGroupResponse.builder().build();
         final PutRetentionPolicyResponse putRetentionPolicyResponse = PutRetentionPolicyResponse.builder().build();
@@ -84,7 +84,7 @@ public class CreateHandlerTest {
     @Test
     public void handleRequest_SuccessGeneratedLogGroupName_ModelIsNull() {
         final DescribeLogGroupsResponse describeResponseInitial = DescribeLogGroupsResponse.builder()
-            .logGroups(Arrays.asList())
+            .logGroups(Collections.emptyList())
             .build();
         final CreateLogGroupResponse createLogGroupResponse = CreateLogGroupResponse.builder().build();
 
@@ -115,7 +115,7 @@ public class CreateHandlerTest {
     @Test
     public void handleRequest_SuccessGeneratedLogGroupName() {
         final DescribeLogGroupsResponse describeResponseInitial = DescribeLogGroupsResponse.builder()
-                .logGroups(Arrays.asList())
+                .logGroups(Collections.emptyList())
                 .build();
         final CreateLogGroupResponse createLogGroupResponse = CreateLogGroupResponse.builder().build();
         final PutRetentionPolicyResponse putRetentionPolicyResponse = PutRetentionPolicyResponse.builder().build();

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,7 +47,7 @@ public class ReadHandlerTest {
                 .retentionInDays(1)
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
-                .logGroups(Arrays.asList(logGroup))
+                .logGroups(Collections.singletonList(logGroup))
                 .build();
 
         doReturn(describeResponse)
@@ -81,7 +81,7 @@ public class ReadHandlerTest {
     @Test
     public void handleRequest_FailureNotFound_EmptyLogGroupResponse() {
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
-                .logGroups(Arrays.asList())
+                .logGroups(Collections.emptyList())
                 .build();
 
         doReturn(describeResponse)

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/UpdateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/UpdateHandlerTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyResponse;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,7 +50,7 @@ public class UpdateHandlerTest {
                 .retentionInDays(1)
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
-                .logGroups(Arrays.asList(logGroup))
+                .logGroups(Collections.singletonList(logGroup))
                 .build();
 
         doReturn(putRetentionPolicyResponse, describeResponse)
@@ -87,7 +88,7 @@ public class UpdateHandlerTest {
             .logGroupName("LogGroup")
             .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
-            .logGroups(Arrays.asList(logGroup))
+            .logGroups(Collections.singletonList(logGroup))
             .build();
 
         doReturn(deleteRetentionPolicyResponse, describeResponse)
@@ -124,14 +125,14 @@ public class UpdateHandlerTest {
             .retentionInDays(1)
             .build();
         final DescribeLogGroupsResponse initialDescribeResponse = DescribeLogGroupsResponse.builder()
-            .logGroups(Arrays.asList(initialLogGroup))
+            .logGroups(Collections.singletonList(initialLogGroup))
             .build();
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
             .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
-            .logGroups(Arrays.asList(logGroup))
+            .logGroups(Collections.singletonList(logGroup))
             .build();
 
         doReturn(initialDescribeResponse, describeResponse)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Use static HTTP client so less memory is consumed. This required an update of the client library, which was causing a mismatch with the specified Logs SDK package. Also fixed some unused imports and best practices around immutable collections in the unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
