### PR TITLE
Add KmsKeyId to LogGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Files local to the user
+/overrides.json
+
 # Compiled class file
 *.class
 
@@ -28,6 +31,9 @@ hs_err_pid*
 
 # Build
 target/
+
+# Test
+.hypothesis/
 
 # Generated Files
 .classpath

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,6 @@ repos:
     - --no-sort-keys
   - id: check-merge-conflict
   - id: check-yaml
+    args:
+    # Needed, or !Sub (and other CloudFormation specific tags will not be recognized)
+    - --unsafe

--- a/aws-logs-loggroup/.gitignore
+++ b/aws-logs-loggroup/.gitignore
@@ -15,6 +15,7 @@ out/
 
 # auto-generated files
 target/
+docs/README.md
 
 # our logs
 rpdk.log

--- a/aws-logs-loggroup/README.md
+++ b/aws-logs-loggroup/README.md
@@ -1,12 +1,12 @@
 # AWS::Logs::LogGroup
 
-Congratulations on starting development! Next steps:
+## Developing
 
-1. Write the JSON schema describing your resource, `aws-logs-loggroup.json`
-2. The RPDK will automatically generate the correct resource model from the
+- The JSON schema describing this resource is `aws-logs-loggroup.json`
+- The RPDK will automatically generate the correct resource model from the
    schema whenever the project is built via Maven. You can also do this manually
    with the following command: `cfn-cli generate`
-3. Implement your resource handlers
+- Resource handlers live in `src/main/java/software/amazon/logs/loggroup`
 
 
 Please don't modify files under `target/generated-sources/rpdk`, as they will be
@@ -15,3 +15,20 @@ automatically overwritten.
 The code use [Lombok](https://projectlombok.org/), and [you may have to install
 IDE integrations](https://projectlombok.org/) to enable auto-complete for
 Lombok-annotated classes.
+
+## Running Contract Tests
+
+1. Create a KMS CMK for use with CloudWatch Logs (see [the CloudWatch
+    Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)).
+2. Edit `overrides.json` so that every `/KmsKeyId` uses the ARN of that key.
+3. Package the code with Maven (`mvn package`)
+4. Run `sam local start-lambda` in one terminal
+5. Run `cfn test` in another terminal. CFN test will use your credentials to test
+    the resource handlers in your account.
+
+Currently the following tests are broken, see issue [\#25](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/issues/25)
+
+- contract_create_read_success
+- contract_create_list_success
+- contract_update_read_success
+- contract_update_list_success

--- a/aws-logs-loggroup/README.md
+++ b/aws-logs-loggroup/README.md
@@ -21,7 +21,7 @@ Lombok-annotated classes.
 You can execute the following commands to run the tests.
 You will need to have docker installed and running.
 
-```shell script
+```bash
 # Create a CloudFormation stack with development dependencies (a KMS CMK)
 # NOTE: this has a monthly cost of 1 USD for the CMK
 aws cloudformation deploy \

--- a/aws-logs-loggroup/aws-logs-loggroup.json
+++ b/aws-logs-loggroup/aws-logs-loggroup.json
@@ -10,6 +10,12 @@
       "maxLength": 512,
       "pattern": "^[.\\-_/#A-Za-z0-9]{1,512}\\Z"
     },
+    "KmsKeyId": {
+      "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.",
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^arn:[a-z0-9-]+:kms:[a-z0-9-]+:\\d{12}:(key|alias)/.+\\Z"
+    },
     "RetentionInDays": {
       "description": "The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.",
       "type": "integer",
@@ -54,6 +60,8 @@
     "update": {
       "permissions": [
         "logs:DescribeLogGroups",
+        "logs:AssociateKmsKey",
+        "logs:DisassociateKmsKey",
         "logs:PutRetentionPolicy",
         "logs:DeleteRetentionPolicy"
       ]

--- a/aws-logs-loggroup/aws-logs-loggroup.json
+++ b/aws-logs-loggroup/aws-logs-loggroup.json
@@ -4,7 +4,7 @@
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs.git",
   "properties": {
     "LogGroupName": {
-      "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group. ",
+      "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
       "type": "string",
       "minLength": 1,
       "maxLength": 512,
@@ -42,7 +42,8 @@
     "create": {
       "permissions": [
         "logs:DescribeLogGroups",
-        "logs:CreateLogGroup"
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy"
       ]
     },
     "read": {

--- a/aws-logs-loggroup/dev-resources.yaml
+++ b/aws-logs-loggroup/dev-resources.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Development dependencies for AWS::Logs::LogGroup
+Resources:
+  Cmk:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS CMK for use with the AWS::Logs::LogGroup resource provider
+      KeyUsage: ENCRYPT_DECRYPT
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: cmk-policy
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+          Action: kms:*
+          Resource: "*"
+        - Sid: CloudWatch Logs Permissions
+          Effect: Allow
+          Principal:
+            Service: !Sub "logs.${AWS::Region}.${AWS::URLSuffix}"
+          Action:
+            - "kms:Encrypt*"
+            - "kms:Decrypt*"
+            - "kms:ReEncrypt*"
+            - "kms:GenerateDataKey*"
+            - "kms:Describe*"
+          Resource: "*"
+  # Alias is only added to show the StackName in the KMS Console
+  CmkAlias:
+    Type: "AWS::KMS::Alias"
+    Properties:
+      AliasName: !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/${AWS::StackName}"
+      TargetKeyId: !Ref Cmk
+Outputs:
+  OverridesJson:
+    Description: Use this as overrides.json
+    Value: !Sub "{\"CREATE\": {\"/KmsKeyId\": \"${Cmk.Arn}\"}}"

--- a/aws-logs-loggroup/overrides.json
+++ b/aws-logs-loggroup/overrides.json
@@ -1,5 +1,0 @@
-{
-  "CREATE": {
-    "/KmsKeyId": "arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-  }
-}

--- a/aws-logs-loggroup/overrides.json
+++ b/aws-logs-loggroup/overrides.json
@@ -1,0 +1,5 @@
+{
+  "CREATE": {
+    "/KmsKeyId": "arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  }
+}

--- a/aws-logs-loggroup/resource-role.yaml
+++ b/aws-logs-loggroup/resource-role.yaml
@@ -23,10 +23,12 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "logs:AssociateKmsKey"
                 - "logs:CreateLogGroup"
                 - "logs:DeleteLogGroup"
                 - "logs:DeleteRetentionPolicy"
                 - "logs:DescribeLogGroups"
+                - "logs:DisassociateKmsKey"
                 - "logs:PutRetentionPolicy"
                 Resource: "*"
 Outputs:

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -51,8 +51,8 @@ final class Translator {
 
     static DeleteRetentionPolicyRequest translateToDeleteRetentionPolicyRequest(final ResourceModel model) {
         return DeleteRetentionPolicyRequest.builder()
-            .logGroupName(model.getLogGroupName())
-            .build();
+                .logGroupName(model.getLogGroupName())
+                .build();
     }
 
     static ResourceModel translateForRead(final DescribeLogGroupsResponse response) {
@@ -62,10 +62,10 @@ final class Translator {
                 .findAny()
                 .orElse(null);
         final String logGroupArn = streamOfOrEmpty(response.logGroups())
-            .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::arn)
-            .filter(Objects::nonNull)
-            .findAny()
-            .orElse(null);
+                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::arn)
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElse(null);
         final Integer retentionInDays = streamOfOrEmpty(response.logGroups())
                 .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::retentionInDays)
                 .filter(Objects::nonNull)

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -6,6 +6,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolic
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.AssociateKmsKeyRequest;
 
 import java.util.Collection;
 import java.util.List;
@@ -39,6 +41,7 @@ final class Translator {
     static CreateLogGroupRequest translateToCreateRequest(final ResourceModel model) {
         return CreateLogGroupRequest.builder()
                 .logGroupName(model.getLogGroupName())
+                .kmsKeyId(model.getKmsKeyId())
                 .build();
     }
 
@@ -52,6 +55,19 @@ final class Translator {
     static DeleteRetentionPolicyRequest translateToDeleteRetentionPolicyRequest(final ResourceModel model) {
         return DeleteRetentionPolicyRequest.builder()
                 .logGroupName(model.getLogGroupName())
+                .build();
+    }
+
+    static DisassociateKmsKeyRequest translateToDisassociateKmsKeyRequest(final ResourceModel model) {
+        return DisassociateKmsKeyRequest.builder()
+                .logGroupName(model.getLogGroupName())
+                .build();
+    }
+
+    static AssociateKmsKeyRequest translateToAssociateKmsKeyRequest(final ResourceModel model) {
+        return AssociateKmsKeyRequest.builder()
+                .logGroupName(model.getLogGroupName())
+                .kmsKeyId(model.getKmsKeyId())
                 .build();
     }
 
@@ -71,10 +87,16 @@ final class Translator {
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElse(null);
+        final String kmsKeyId = streamOfOrEmpty(response.logGroups())
+                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::kmsKeyId)
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElse(null);
         return ResourceModel.builder()
                 .arn(logGroupArn)
                 .logGroupName(logGroupName)
                 .retentionInDays(retentionInDays)
+                .kmsKeyId(kmsKeyId)
                 .build();
     }
 
@@ -84,6 +106,7 @@ final class Translator {
                         .arn(logGroup.arn())
                         .logGroupName(logGroup.logGroupName())
                         .retentionInDays(logGroup.retentionInDays())
+                        .kmsKeyId(logGroup.kmsKeyId())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
@@ -21,7 +21,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        // Everything except RetentionPolicyInDays KmsKeyId is createOnly
+        // Everything except RetentionPolicyInDays and KmsKeyId is createOnly
         final ResourceModel model = request.getDesiredResourceState();
 
         if (model.getRetentionInDays() == null) {

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
@@ -53,6 +53,7 @@ public class CreateHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         doReturn(describeResponseInitial, createLogGroupResponse, putRetentionPolicyResponse)
@@ -65,6 +66,7 @@ public class CreateHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -131,6 +133,7 @@ public class CreateHandlerTest {
 
         final ResourceModel model = ResourceModel.builder()
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -171,6 +174,7 @@ public class CreateHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/DeleteHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/DeleteHandlerTest.java
@@ -48,6 +48,7 @@ public class DeleteHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(logGroup))
@@ -63,6 +64,7 @@ public class DeleteHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -93,6 +95,7 @@ public class DeleteHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ListHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ListHandlerTest.java
@@ -42,10 +42,12 @@ public class ListHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
         final LogGroup logGroup2 = LogGroup.builder()
                 .logGroupName("LogGroup2")
                 .retentionInDays(2)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
                 .logGroups(Arrays.asList(logGroup, logGroup2))
@@ -62,11 +64,13 @@ public class ListHandlerTest {
         final ResourceModel model1 = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceModel model2 = ResourceModel.builder()
                 .logGroupName("LogGroup2")
                 .retentionInDays(2)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
@@ -45,6 +45,7 @@ public class ReadHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(logGroup))
@@ -60,6 +61,7 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -94,6 +96,7 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -116,6 +119,7 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsReq
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.AssociateKmsKeyRequest;
 
 import java.util.Collections;
 
@@ -19,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TranslatorTest {
     private static final ResourceModel RESOURCE_MODEL = ResourceModel.builder()
         .retentionInDays(1)
+        .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
         .logGroupName("LogGroup")
         .build();
 
@@ -51,6 +54,7 @@ public class TranslatorTest {
     public void testTranslateToCreate() {
         final CreateLogGroupRequest request = CreateLogGroupRequest.builder()
             .logGroupName(RESOURCE_MODEL.getLogGroupName())
+            .kmsKeyId(RESOURCE_MODEL.getKmsKeyId())
             .build();
         assertThat(Translator.translateToCreateRequest(RESOURCE_MODEL)).isEqualToComparingFieldByField(request);
     }
@@ -77,10 +81,32 @@ public class TranslatorTest {
     }
 
     @Test
+    public void testTranslateToDisassociateKmsKeyRequest() {
+        final DisassociateKmsKeyRequest request = DisassociateKmsKeyRequest.builder()
+            .logGroupName(RESOURCE_MODEL.getLogGroupName())
+            .build();
+
+        assertThat(Translator.translateToDisassociateKmsKeyRequest(RESOURCE_MODEL))
+            .isEqualToComparingFieldByField(request);
+    }
+
+    @Test
+    public void testTranslateToAssociateKmsKeyRequest() {
+        final AssociateKmsKeyRequest request = AssociateKmsKeyRequest.builder()
+            .logGroupName(RESOURCE_MODEL.getLogGroupName())
+            .kmsKeyId(RESOURCE_MODEL.getKmsKeyId())
+            .build();
+
+        assertThat(Translator.translateToAssociateKmsKeyRequest(RESOURCE_MODEL))
+            .isEqualToComparingFieldByField(request);
+    }
+
+    @Test
     public void testTranslateForRead() {
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
 
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/UpdateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/UpdateHandlerTest.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolic
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyResponse;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,6 +49,7 @@ public class UpdateHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(logGroup))
@@ -63,6 +65,7 @@ public class UpdateHandlerTest {
         final ResourceModel model = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -86,6 +89,7 @@ public class UpdateHandlerTest {
         final DeleteRetentionPolicyResponse deleteRetentionPolicyResponse = DeleteRetentionPolicyResponse.builder().build();
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
             .logGroups(Collections.singletonList(logGroup))
@@ -100,6 +104,7 @@ public class UpdateHandlerTest {
 
         final ResourceModel model = ResourceModel.builder()
             .logGroupName("LogGroup")
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -119,10 +124,50 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    public void handleRequest_Success_KmsKeyIdDeleted() {
+        final DisassociateKmsKeyResponse disassociateKmsKeyResponse = DisassociateKmsKeyResponse.builder().build();
+        final LogGroup logGroup = LogGroup.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .build();
+        final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
+                .logGroups(Collections.singletonList(logGroup))
+                .build();
+
+        doReturn(disassociateKmsKeyResponse, describeResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.any(),
+                        ArgumentMatchers.any()
+                );
+
+        final ResourceModel model = ResourceModel.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getResourceModel()).isEqualToComparingFieldByField(logGroup);
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
     public void handleRequest_SuccessNoChange() {
         final LogGroup initialLogGroup = LogGroup.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
         final DescribeLogGroupsResponse initialDescribeResponse = DescribeLogGroupsResponse.builder()
             .logGroups(Collections.singletonList(initialLogGroup))
@@ -130,6 +175,7 @@ public class UpdateHandlerTest {
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
             .logGroups(Collections.singletonList(logGroup))
@@ -145,6 +191,7 @@ public class UpdateHandlerTest {
         final ResourceModel model = ResourceModel.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -175,6 +222,7 @@ public class UpdateHandlerTest {
         final ResourceModel model = ResourceModel.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()


### PR DESCRIPTION
~This is a Work in Progress, if that's better as an issue, let me know.~

I tried to tackle the difficult parts first, which for me besides the whole of Java is writing test. I haven't started writing code yet. Assistance with both parts is very welcome.

I'm opening this PR mainly to get feedback on the approach. Currently I have the following questions related to the work already in here:

- Spec is step 1, so that can already get a decent review :)
- Is this the way to update the tests, or do we prefer completely new tests that only deal with the KmsKeyId

I also have question for the work that isn't in here yet:

- There are three related methods in the API: "CreateLogGroup" with the "kmsKeyId" parameter, "AssociateKmsKey" and "DisassociateKmsKey"
- This allows to approaches in the CreateHandler. Doing it in two calls (CreateLogGroup without kmsKeyId and AssociateKmsKey if it's not Null on the model), which leaves the LogGroup without encryption for some time (and in that time some messages might appear). Or doing it in one call, which uses a different flow for the createHandler and the updateHandler.
- In the updateHandler we have to do it in two steps, which is something that we either shouldn't support (only allowing going from encrypted to plaintext and vice versa) or should highlight in the documentation. The risk of log lines arriving while this change is in progress is even higher than with the CreateHandler.

We should probably decide on the best approach before writing the code.


-----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
