### PR TITLE
added logic to include stack name in loggroup name when empty

### DIFF
--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
@@ -64,7 +64,6 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
     private String generateName(final ResourceHandlerRequest<ResourceModel> request) {
         final StringBuilder identifierPrefix = new StringBuilder();
-        // the prefix will be <stack-name>-<resource type>
         identifierPrefix.append((request.getSystemTags() != null &&
                 MapUtils.isNotEmpty(request.getSystemTags())) ?
                 request.getSystemTags().get("aws:cloudformation:stack-name") + "-" : "");
@@ -72,7 +71,6 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 DEFAULT_LOG_GROUP_NAME_PREFIX :
                 request.getLogicalResourceIdentifier());
 
-        // This utility function will add the auto-generated ID after the prefix.
         return IdentifierUtils.generateResourceIdentifier(
                 identifierPrefix.toString(),
                 request.getClientRequestToken(),

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
@@ -62,7 +62,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         }
     }
 
-    private static String generateName(final ResourceHandlerRequest<ResourceModel> request) {
+    private String generateName(final ResourceHandlerRequest<ResourceModel> request) {
         final StringBuilder identifierPrefix = new StringBuilder();
         // the prefix will be <stack-name>-<resource type>
         identifierPrefix.append((request.getSystemTags() != null &&

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
@@ -151,7 +151,7 @@ public class CreateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel().getLogGroupName()).contains("unit_test_Stack");
+        assertThat(response.getResourceModel().getLogGroupName()).startsWith("unit_test_Stack");
         assertThat(response.getResourceModels()).isNull();
         // There isn't an easy way to check the generated value of the name
         assertThat(response.getResourceModel()).isNotNull();

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/CreateHandlerTest.java
@@ -19,6 +19,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRe
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceAlreadyExistsException;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -137,12 +139,19 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
+        final Map<String, String> systemTags = new HashMap<>();
+        systemTags.put("aws:cloudformation:stack-name", "unit_test_Stack");
+        request.setSystemTags(systemTags);
+        request.setClientRequestToken("4b90a7e4-b790-456b-a937-0cfdfa212fed");
+        request.setLogicalResourceIdentifier("taskDefinition");
+
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getLogGroupName()).contains("unit_test_Stack");
         assertThat(response.getResourceModels()).isNull();
         // There isn't an easy way to check the generated value of the name
         assertThat(response.getResourceModel()).isNotNull();


### PR DESCRIPTION
*Issue #, if available:*
improper naming convention of loggroup

*Description of changes:*
added logic for the case if in the input request loggroup name is empty then include stack name in the generated string for loggroup name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
