### PR TITLE
LogGroup: Remove dependency to SDK v1

### DIFF
--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -74,11 +74,6 @@
             <version>2.26.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-logs</artifactId>
-            <version>1.11.592</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Remove dependency to SDK v1. We already have a dependency to v2.

https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/blob/3dcd55b8e95cc76ccf9f2fb64318f0b2bbbd5547/aws-logs-loggroup/pom.xml#L43-L47


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
