### PR TITLE
Remove callchain approach from MetricFilter resource type to reduce latency in stack operations

### DIFF
--- a/aws-logs-metricfilter/README.md
+++ b/aws-logs-metricfilter/README.md
@@ -1,12 +1,12 @@
 # AWS::Logs::MetricFilter
 
-Congratulations on starting development! Next steps:
-
-1. Write the JSON schema describing your resource, `aws-logs-metricfilter.json`
-1. Implement your resource handlers.
-
+## Development
 The RPDK will automatically generate the correct resource model from the schema whenever the project is built via Maven. You can also do this manually with the following command: `cfn generate`.
 
 > Please don't modify files under `target/generated-sources/rpdk`, as they will be automatically overwritten.
 
 The code uses [Lombok](https://projectlombok.org/), and [you may have to install IDE integrations](https://projectlombok.org/setup/overview) to enable auto-complete for Lombok-annotated classes.
+
+### Running contract tests
+
+Prior to running `cfn test`, ensure that you have created a LogGroup with the name specified in file `overrides.json`. Do this in the AWS region that the tests run in.

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
@@ -1,20 +1,12 @@
 package software.amazon.logs.metricfilter;
 
 import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
-import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.LimitExceededException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.OperationAbortedException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutMetricFilterRequest;
-import software.amazon.awssdk.services.cloudwatchlogs.model.PutMetricFilterResponse;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ServiceUnavailableException;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
-import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -22,7 +14,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
 public class CreateHandler extends BaseHandlerStd {
-    private Logger logger;
     // if you change the value in the line below, please also update the resource schema
     private static final int MAX_LENGTH_METRIC_FILTER_NAME = 512;
 
@@ -32,8 +23,6 @@ public class CreateHandler extends BaseHandlerStd {
         final CallbackContext callbackContext,
         final ProxyClient<CloudWatchLogsClient> proxyClient,
         final Logger logger) {
-
-        this.logger = logger;
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -49,50 +38,21 @@ public class CreateHandler extends BaseHandlerStd {
                     )
             );
         }
-
-        return ProgressEvent.progress(model, callbackContext)
-            .then(progress ->
-                preCreateCheck(proxy, callbackContext, proxyClient, model)
-                    .done((response) -> {
-                        if (response.metricFilters().isEmpty()) {
-                            return ProgressEvent.progress(model, callbackContext);
-                        }
-                        return ProgressEvent.defaultFailureHandler(new CfnAlreadyExistsException(null), HandlerErrorCode.AlreadyExists);
-                    })
-            )
-            .then(progress ->
-                proxy.initiate("AWS-Logs-MetricFilter::Create", proxyClient, model, callbackContext)
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
-                    .makeServiceCall(this::createResource)
-                    .progress())
-            .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
-    }
-
-
-    /**
-     * Implement client invocation of the create request through the proxyClient, which is already initialised with
-     * caller credentials, correct region and retry settings
-     * @param awsRequest the aws service request to create a resource
-     * @param proxyClient the aws service client to make the call
-     * @return awsResponse create resource response
-     */
-    private PutMetricFilterResponse createResource(
-        final PutMetricFilterRequest awsRequest,
-        final ProxyClient<CloudWatchLogsClient> proxyClient) {
-        PutMetricFilterResponse awsResponse;
         try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::putMetricFilter);
-        } catch (final InvalidParameterException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
-        } catch (final LimitExceededException e) {
-            throw new CfnServiceLimitExceededException(e);
-        } catch (final OperationAbortedException e) {
-            throw new CfnResourceConflictException(e);
-        } catch (final ServiceUnavailableException e) {
-            throw new CfnServiceInternalErrorException(e);
-        }
+            boolean exists = exists(proxyClient, model);
+            if (exists) {
+                CfnAlreadyExistsException error = new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getPrimaryIdentifier().toString());
+                return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
+            }
+            final PutMetricFilterRequest putRequest = Translator.translateToCreateRequest(model);
 
-        logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+            proxyClient.injectCredentialsAndInvokeV2(putRequest, proxyClient.client()::putMetricFilter);
+            logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
+            return ProgressEvent.defaultSuccessHandler(model);
+        } catch (final AwsServiceException e) {
+            BaseHandlerException error = Translator.translateException(e);
+            return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
+
+        }
     }
 }

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/DeleteHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/DeleteHandler.java
@@ -1,25 +1,16 @@
 package software.amazon.logs.metricfilter;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteMetricFilterRequest;
-import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteMetricFilterResponse;
-import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.OperationAbortedException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ServiceUnavailableException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
-import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -28,39 +19,16 @@ public class DeleteHandler extends BaseHandlerStd {
         final ProxyClient<CloudWatchLogsClient> proxyClient,
         final Logger logger) {
 
-        this.logger = logger;
-
         final ResourceModel model = request.getDesiredResourceState();
+        final DeleteMetricFilterRequest deleteMetricFilterRequest = Translator.translateToDeleteRequest(model);
 
-        this.logger.log(String.format("Trying to delete model %s", model.getPrimaryIdentifier()));
-
-        return proxy.initiate("AWS-Logs-MetricFilter::Delete", proxyClient, model, callbackContext)
-                .translateToServiceRequest(Translator::translateToDeleteRequest)
-                .makeServiceCall(this::deleteResource)
-                .done(awsResponse -> ProgressEvent.<ResourceModel, CallbackContext>builder()
-                    .status(OperationStatus.SUCCESS)
-                    .resourceModel(model)
-                    .build());
-    }
-
-    private DeleteMetricFilterResponse deleteResource(
-        final DeleteMetricFilterRequest awsRequest,
-        final ProxyClient<CloudWatchLogsClient> proxyClient) {
-        DeleteMetricFilterResponse awsResponse;
         try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::deleteMetricFilter);
-        } catch (ResourceNotFoundException e) {
-            logger.log("Resource does not exist and could not be deleted.");
-            throw new CfnNotFoundException(e);
-        } catch (InvalidParameterException e) {
-            throw new CfnInvalidRequestException(e);
-        } catch (OperationAbortedException e) {
-            throw new CfnResourceConflictException(e);
-        } catch (ServiceUnavailableException e) {
-            throw new CfnServiceInternalErrorException(e);
+            proxyClient.injectCredentialsAndInvokeV2(deleteMetricFilterRequest, proxyClient.client()::deleteMetricFilter);
+        } catch (final AwsServiceException e) {
+            BaseHandlerException error = Translator.translateException(e);
+            return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
         }
-
         logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+        return ProgressEvent.defaultSuccessHandler(model);
     }
 }

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ListHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ListHandler.java
@@ -1,13 +1,9 @@
 package software.amazon.logs.metricfilter;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFiltersRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFiltersResponse;
-import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ServiceUnavailableException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -30,12 +26,9 @@ public class ListHandler extends BaseHandler<CallbackContext> {
 
         try {
             awsResponse = proxy.injectCredentialsAndInvokeV2(awsRequest, ClientBuilder.getClient()::describeMetricFilters);
-        } catch (InvalidParameterException e) {
-            throw new CfnInvalidRequestException(e);
-        } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(e);
-        } catch (ServiceUnavailableException e) {
-            throw new CfnServiceInternalErrorException(e);
+        } catch (final AwsServiceException e) {
+            BaseHandlerException error = Translator.translateException(e);
+            return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
         }
 
         final List<ResourceModel> models = Translator.translateFromListResponse(awsResponse);

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ReadHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ReadHandler.java
@@ -1,17 +1,13 @@
 package software.amazon.logs.metricfilter;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFiltersRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFiltersResponse;
-import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ServiceUnavailableException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -19,7 +15,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import java.util.Objects;
 
 public class ReadHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -28,48 +23,25 @@ public class ReadHandler extends BaseHandlerStd {
         final ProxyClient<CloudWatchLogsClient> proxyClient,
         final Logger logger) {
 
-        this.logger = logger;
-
         final ResourceModel model = request.getDesiredResourceState();
-
-        logger.log("Trying to read resource...");
-
-        return proxy.initiate("AWS-Logs-MetricFilter::Read", proxyClient, model, callbackContext)
-            .translateToServiceRequest(Translator::translateToReadRequest)
-            .makeServiceCall((awsRequest, sdkProxyClient) -> readResource(awsRequest, sdkProxyClient , model))
-            .done(awsResponse -> ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .status(OperationStatus.SUCCESS)
-                .resourceModel(Translator.translateFromReadResponse(awsResponse))
-                .build());
-    }
-
-    private DescribeMetricFiltersResponse readResource(
-        final DescribeMetricFiltersRequest awsRequest,
-        final ProxyClient<CloudWatchLogsClient> proxyClient,
-        final ResourceModel model) {
+        final DescribeMetricFiltersRequest describeMetricFiltersRequest = Translator.translateToReadRequest(model);
         DescribeMetricFiltersResponse awsResponse;
         try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeMetricFilters);
-        } catch (InvalidParameterException e) {
-            throw new CfnInvalidRequestException(e);
-        } catch (ResourceNotFoundException e) {
-            throw new CfnNotFoundException(e);
-        } catch (ServiceUnavailableException e) {
-            throw new CfnServiceInternalErrorException(e);
+            awsResponse = proxyClient.injectCredentialsAndInvokeV2(describeMetricFiltersRequest, proxyClient.client()::describeMetricFilters);
+        } catch (final AwsServiceException e) {
+            BaseHandlerException error = Translator.translateException(e);
+            return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
         }
 
         if (awsResponse.metricFilters().isEmpty()) {
-            logger.log("Resource does not exist.");
-            throw new CfnNotFoundException(ResourceModel.TYPE_NAME,
+            logger.log(String.format("Resource with id %s does not exist." , model.getPrimaryIdentifier()));
+            BaseHandlerException error = new CfnNotFoundException(ResourceModel.TYPE_NAME,
                     Objects.toString(model.getPrimaryIdentifier()));
+            return ProgressEvent.defaultFailureHandler(error, Translator.translateToErrorCode(error));
         }
+        ResourceModel readModel = Translator.translateFromReadResponse(awsResponse);
 
         logger.log(String.format("%s has successfully been read." , ResourceModel.TYPE_NAME));
-        return awsResponse;
+        return ProgressEvent.defaultSuccessHandler(readModel);
     }
-
-    private ProgressEvent<ResourceModel, CallbackContext> constructResourceModelFromResponse(final DescribeMetricFiltersResponse awsResponse) {
-        return ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse));
-    }
-
 }

--- a/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/DeleteHandlerTest.java
+++ b/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/DeleteHandlerTest.java
@@ -7,9 +7,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteMetricFilterRe
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteMetricFilterResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -23,9 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,7 +52,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
     @AfterEach
     public void tear_down() {
-        verify(sdkClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(sdkClient);
     }
 
@@ -93,8 +89,10 @@ public class DeleteHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
-                .isInstanceOf(CfnNotFoundException.class);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 
     @Test
@@ -108,7 +106,9 @@ public class DeleteHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
-                .isInstanceOf(CfnInvalidRequestException.class);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
     }
 }

--- a/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/ReadHandlerTest.java
+++ b/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/ReadHandlerTest.java
@@ -8,9 +8,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFilter
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeMetricFiltersResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -24,9 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -56,7 +53,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @AfterEach
     public void tear_down() {
-        verify(sdkClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(sdkClient);
     }
 
@@ -102,8 +98,10 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
-                .isInstanceOf(CfnNotFoundException.class);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 
     @Test
@@ -117,8 +115,10 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
-                .isInstanceOf(CfnNotFoundException.class);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 
     @Test
@@ -132,7 +132,9 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
-                .isInstanceOf(CfnInvalidRequestException.class);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/issues/39

*Description of changes:* 

- `cfn test` passes: `========= 12 passed, 7 warnings in 214.08s (0:03:34) =========`
- Integration tests pass

Before this change:

![image](https://user-images.githubusercontent.com/5374887/85912297-60094900-b7e0-11ea-87b0-1db6b9289063.png)

With this change:

![image](https://user-images.githubusercontent.com/5374887/85912307-73b4af80-b7e0-11ea-89c5-8cd2a302aa8d.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
