### PR TITLE
Remove call to Read handler at the end of Create & Update, to reduce latency in stack operations

### DIFF
--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
@@ -50,6 +50,8 @@ public class CreateHandler extends BaseHandlerStd {
             );
         }
 
+        logger.log("trying with no read handler at the end...");
+
         return ProgressEvent.progress(model, callbackContext)
             .then(progress ->
                 preCreateCheck(proxy, callbackContext, proxyClient, model)
@@ -65,7 +67,7 @@ public class CreateHandler extends BaseHandlerStd {
                     .translateToServiceRequest(Translator::translateToCreateRequest)
                     .makeServiceCall(this::createResource)
                     .progress())
-            .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+            .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 
 

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ReadHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/ReadHandler.java
@@ -32,8 +32,6 @@ public class ReadHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        logger.log("Trying to read resource...");
-
         return proxy.initiate("AWS-Logs-MetricFilter::Read", proxyClient, model, callbackContext)
             .translateToServiceRequest(Translator::translateToReadRequest)
             .makeServiceCall((awsRequest, sdkProxyClient) -> readResource(awsRequest, sdkProxyClient , model))

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/UpdateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/UpdateHandler.java
@@ -62,7 +62,7 @@ public class UpdateHandler extends BaseHandlerStd {
                     .translateToServiceRequest(Translator::translateToUpdateRequest)
                     .makeServiceCall(this::updateResource)
                     .progress())
-            .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+            .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 
     private boolean isUpdatable(final ResourceModel model, final ResourceModel previousModel) {

--- a/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/CreateHandlerTest.java
+++ b/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/CreateHandlerTest.java
@@ -98,7 +98,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        verify(proxyClient.client(), times(2)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
+        verify(proxyClient.client(), times(1)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
         verify(proxyClient.client(), times(1)).putMetricFilter(any(PutMetricFilterRequest.class));
     }
 
@@ -138,7 +138,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        verify(proxyClient.client(), times(2)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
+        verify(proxyClient.client(), times(1)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
         verify(proxyClient.client(), times(1)).putMetricFilter(any(PutMetricFilterRequest.class));
     }
 

--- a/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/UpdateHandlerTest.java
+++ b/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/UpdateHandlerTest.java
@@ -85,7 +85,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        verify(proxyClient.client(), times(2)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
+        verify(proxyClient.client(), times(1)).describeMetricFilters(any(DescribeMetricFiltersRequest.class));
         verify(proxyClient.client(), times(1)).putMetricFilter(any(PutMetricFilterRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(sdkClient);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/issues/39

*Description of changes:* Remove read at the end to reduce latency in stack operations

- `cfn test` passes: `================== 12 passed, 7 warnings in 208.31s (0:03:28) ==================`
- Integration tests:

Before this change:

![image](https://user-images.githubusercontent.com/5374887/86033226-76d0bb00-b9ed-11ea-8da5-c26fdb2bd0ed.png)


With this change:

![image](https://user-images.githubusercontent.com/5374887/86034200-fa3edc00-b9ee-11ea-9e7e-e61fb6eaa579.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
