### PR TITLE
Metric Filter: Add validation and documentation (#37)

### DIFF
--- a/aws-logs-loggroup/docs/README.md
+++ b/aws-logs-loggroup/docs/README.md
@@ -1,0 +1,74 @@
+# AWS::Logs::LogGroup
+
+Resource schema for AWS::Logs::LogGroup
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::Logs::LogGroup",
+    "Properties" : {
+        "<a href="#loggroupname" title="LogGroupName">LogGroupName</a>" : <i>String</i>,
+        "<a href="#retentionindays" title="RetentionInDays">RetentionInDays</a>" : <i>Double</i>,
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::Logs::LogGroup
+Properties:
+    <a href="#loggroupname" title="LogGroupName">LogGroupName</a>: <i>String</i>
+    <a href="#retentionindays" title="RetentionInDays">RetentionInDays</a>: <i>Double</i>
+</pre>
+
+## Properties
+
+#### LogGroupName
+
+The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>512</code>
+
+_Pattern_: <code>^[.\-_/#A-Za-z0-9]{1,512}\Z</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### RetentionInDays
+
+The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
+
+_Required_: No
+
+_Type_: Double
+
+_Allowed Values_: <code>1</code> | <code>3</code> | <code>5</code> | <code>7</code> | <code>14</code> | <code>30</code> | <code>60</code> | <code>90</code> | <code>120</code> | <code>150</code> | <code>180</code> | <code>365</code> | <code>400</code> | <code>545</code> | <code>731</code> | <code>1827</code> | <code>3653</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the LogGroupName.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### Arn
+
+The CloudWatch log group ARN.

--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.10.49</version>
+            <version>2.13.18</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->

--- a/aws-logs-metricfilter/aws-logs-metricfilter.json
+++ b/aws-logs-metricfilter/aws-logs-metricfilter.json
@@ -35,6 +35,7 @@
         "MetricValue": {
           "description": "The value to publish to the CloudWatch metric when a filter pattern matches a log event.",
           "type": "string",
+          "pattern": ".{1,100}",
           "minLength": 1,
           "maxLength": 100
         }

--- a/aws-logs-metricfilter/docs/README.md
+++ b/aws-logs-metricfilter/docs/README.md
@@ -1,0 +1,89 @@
+# AWS::Logs::MetricFilter
+
+Specifies a metric filter that describes how CloudWatch Logs extracts information from logs and transforms it into Amazon CloudWatch metrics.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::Logs::MetricFilter",
+    "Properties" : {
+        "<a href="#filtername" title="FilterName">FilterName</a>" : <i>String</i>,
+        "<a href="#filterpattern" title="FilterPattern">FilterPattern</a>" : <i>String</i>,
+        "<a href="#loggroupname" title="LogGroupName">LogGroupName</a>" : <i>String</i>,
+        "<a href="#metrictransformations" title="MetricTransformations">MetricTransformations</a>" : <i>[ <a href="metrictransformations.md">MetricTransformations</a>, ... ]</i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::Logs::MetricFilter
+Properties:
+    <a href="#filtername" title="FilterName">FilterName</a>: <i>String</i>
+    <a href="#filterpattern" title="FilterPattern">FilterPattern</a>: <i>String</i>
+    <a href="#loggroupname" title="LogGroupName">LogGroupName</a>: <i>String</i>
+    <a href="#metrictransformations" title="MetricTransformations">MetricTransformations</a>: <i>
+      - <a href="metrictransformations.md">MetricTransformations</a></i>
+</pre>
+
+## Properties
+
+#### FilterName
+
+A name for the metric filter.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>512</code>
+
+_Pattern_: <code>^[^:*]{1,512}</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### FilterPattern
+
+Pattern that Logs follows to interpret each entry in a log.
+
+_Required_: Yes
+
+_Type_: String
+
+_Maximum_: <code>1024</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### LogGroupName
+
+Existing log group that you want to associate with this filter.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>512</code>
+
+_Pattern_: <code>^[.\-_/#A-Za-z0-9]{1,512}</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### MetricTransformations
+
+A collection of information that defines how metric data gets emitted.
+
+_Required_: Yes
+
+_Type_: List of <a href="metrictransformations.md">MetricTransformations</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-logs-metricfilter/docs/metrictransformations.md
+++ b/aws-logs-metricfilter/docs/metrictransformations.md
@@ -1,0 +1,85 @@
+# AWS::Logs::MetricFilter MetricTransformations
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#defaultvalue" title="DefaultValue">DefaultValue</a>" : <i>Double</i>,
+    "<a href="#metricname" title="MetricName">MetricName</a>" : <i>String</i>,
+    "<a href="#metricnamespace" title="MetricNamespace">MetricNamespace</a>" : <i>String</i>,
+    "<a href="#metricvalue" title="MetricValue">MetricValue</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#defaultvalue" title="DefaultValue">DefaultValue</a>: <i>Double</i>
+<a href="#metricname" title="MetricName">MetricName</a>: <i>String</i>
+<a href="#metricnamespace" title="MetricNamespace">MetricNamespace</a>: <i>String</i>
+<a href="#metricvalue" title="MetricValue">MetricValue</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### DefaultValue
+
+The value to emit when a filter pattern does not match a log event. This value can be null.
+
+_Required_: No
+
+_Type_: Double
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MetricName
+
+The name of the CloudWatch metric. Metric name must be in ASCII format.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>255</code>
+
+_Pattern_: <code>^((?![:*$])[\x00-\x7F]){1,255}</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MetricNamespace
+
+The namespace of the CloudWatch metric.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>256</code>
+
+_Pattern_: <code>^[0-9a-zA-Z\.\-_\/#]{1,256}</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MetricValue
+
+The value to publish to the CloudWatch metric when a filter pattern matches a log event.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>100</code>
+
+_Pattern_: <code>.{1,100}</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
*Issue #, if available:* N/A.

*Description of changes:* Fix [failing Travis build](https://travis-ci.com/github/aws-cloudformation/aws-cloudformation-resource-providers-logs/builds/173563588)

```
[INFO] --- exec-maven-plugin:1.6.0:exec (generate) @ aws-logs-loggroup-handler ---
'aws-cloudformation-rpdk-java-plugin' 1.0.2 is no longer supported.Please update it in pom.xml to version 2.0.0 or above.
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
