### PR TITLE
Bump rpdk version for LogGroup type

### DIFF
--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.10.49</version>
+            <version>2.13.18</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->


### PR DESCRIPTION
*Issue #, if available:* N/A.

*Description of changes:* Fix [failing Travis build](https://travis-ci.com/github/aws-cloudformation/aws-cloudformation-resource-providers-logs/builds/173563588)

```
[INFO] --- exec-maven-plugin:1.6.0:exec (generate) @ aws-logs-loggroup-handler ---
'aws-cloudformation-rpdk-java-plugin' 1.0.2 is no longer supported.Please update it in pom.xml to version 2.0.0 or above.
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
