### PR TITLE
Upgrade to 2.0.0 and fix pre exist check

### DIFF
--- a/aws-logs-metricfilter/.rpdk-config
+++ b/aws-logs-metricfilter/.rpdk-config
@@ -11,6 +11,7 @@
             "logs",
             "metricfilter"
         ],
-        "codegen_template_path": "guided_aws"
+        "codegen_template_path": "guided_aws",
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-logs-metricfilter/pom.xml
+++ b/aws-logs-metricfilter/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.4</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.10.49</version>
+            <version>2.13.18</version>
         </dependency>
     </dependencies>
 

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
@@ -57,7 +57,7 @@ public class CreateHandler extends BaseHandlerStd {
                         if (response.metricFilters().isEmpty()) {
                             return ProgressEvent.progress(model, callbackContext);
                         }
-                        return ProgressEvent.defaultFailureHandler(new CfnAlreadyExistsException(null), HandlerErrorCode.AlreadyExists);
+                        return ProgressEvent.defaultFailureHandler(new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getPrimaryIdentifier().toString()), HandlerErrorCode.AlreadyExists);
                     })
             )
             .then(progress ->

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/UpdateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/UpdateHandler.java
@@ -53,7 +53,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 preCreateCheck(proxy, callbackContext, proxyClient, model)
                     .done((response) -> {
                         if (response.metricFilters().isEmpty()) {
-                            return ProgressEvent.defaultFailureHandler(new CfnNotFoundException(null), HandlerErrorCode.NotFound);
+                            return ProgressEvent.defaultFailureHandler(new CfnNotFoundException(ResourceModel.TYPE_NAME, model.getPrimaryIdentifier().toString()), HandlerErrorCode.NotFound);
                         }
                         return ProgressEvent.progress(model, callbackContext);
                     })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Upgrade to 2.0.0 will have unit test fail.  There are a couple of things cause those unit test fails:
 - 2.0.0 includes a fix to base exception and use passing exception message (https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/commit/9098f4de41c0ed74165844c745712cde2e1b582d), this will cause NPE in current code just doing `new CfnAlreadyExistsException(null)`. Also this is pretty bad as without any information as before.
 -  The `handleError`  in `preCreateCheck` method doesn't handle exception well. It treats any other exception as successful. However, it should only treat `ResourceNotFound` as successful. Any other exception should be Internal error. In such way, it's able to catch the NPE problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
