### PR TITLE
Add tag support to LogGroup resource

### DIFF
--- a/aws-logs-loggroup/aws-logs-loggroup.json
+++ b/aws-logs-loggroup/aws-logs-loggroup.json
@@ -2,6 +2,32 @@
   "typeName": "AWS::Logs::LogGroup",
   "description": "Resource schema for AWS::Logs::LogGroup",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs.git",
+  "definitions": {
+    "Tag": {
+      "description": "A key-value pair to associate with a resource.",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "type": "string",
+          "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., :, /, =, +, - and @.",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^([\\w\\s\\d_.:/=+\\-@]+)$"
+        },
+        "Value": {
+          "type": "string",
+          "description": "The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., :, /, =, +, - and @.",
+          "minLength": 0,
+          "maxLength": 256,
+          "pattern": "^([\\w\\s\\d_.:/=+\\-@]*)$"
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ]
+    }
+  },
   "properties": {
     "LogGroupName": {
       "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
@@ -39,6 +65,15 @@
         3653
       ]
     },
+    "Tags": {
+      "description": "An array of key-value pairs to apply to this resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "insertionOrder": false,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    },
     "Arn": {
       "description": "The CloudWatch log group ARN.",
       "type": "string"
@@ -49,12 +84,14 @@
       "permissions": [
         "logs:DescribeLogGroups",
         "logs:CreateLogGroup",
-        "logs:PutRetentionPolicy"
+        "logs:PutRetentionPolicy",
+        "logs:TagLogGroup"
       ]
     },
     "read": {
       "permissions": [
-        "logs:DescribeLogGroups"
+        "logs:DescribeLogGroups",
+        "logs:ListTagsLogGroup"
       ]
     },
     "update": {
@@ -63,7 +100,9 @@
         "logs:AssociateKmsKey",
         "logs:DisassociateKmsKey",
         "logs:PutRetentionPolicy",
-        "logs:DeleteRetentionPolicy"
+        "logs:DeleteRetentionPolicy",
+        "logs:TagLogGroup",
+        "logs:UntagLogGroup"
       ]
     },
     "delete": {
@@ -74,7 +113,8 @@
     },
     "list": {
       "permissions": [
-        "logs:DescribeLogGroups"
+        "logs:DescribeLogGroups",
+        "logs:ListTagsLogGroup"
       ]
     }
   },

--- a/aws-logs-loggroup/aws-logs-loggroup.json
+++ b/aws-logs-loggroup/aws-logs-loggroup.json
@@ -11,15 +11,13 @@
           "type": "string",
           "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., :, /, =, +, - and @.",
           "minLength": 1,
-          "maxLength": 128,
-          "pattern": "^([\\w\\s\\d_.:/=+\\-@]+)$"
+          "maxLength": 128
         },
         "Value": {
           "type": "string",
           "description": "The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., :, /, =, +, - and @.",
           "minLength": 0,
-          "maxLength": 256,
-          "pattern": "^([\\w\\s\\d_.:/=+\\-@]*)$"
+          "maxLength": 256
         }
       },
       "required": [

--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <awssdk.version>2.15.19</awssdk.version>
     </properties>
 
     <repositories>
@@ -43,7 +44,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.15.26</version>
+            <version>${awssdk.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->

--- a/aws-logs-loggroup/pom.xml
+++ b/aws-logs-loggroup/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.13.18</version>
+            <version>2.15.26</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->

--- a/aws-logs-loggroup/resource-role.yaml
+++ b/aws-logs-loggroup/resource-role.yaml
@@ -29,7 +29,10 @@ Resources:
                 - "logs:DeleteRetentionPolicy"
                 - "logs:DescribeLogGroups"
                 - "logs:DisassociateKmsKey"
+                - "logs:ListTagsLogGroup"
                 - "logs:PutRetentionPolicy"
+                - "logs:TagLogGroup"
+                - "logs:UntagLogGroup"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Configuration.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Configuration.java
@@ -2,8 +2,10 @@ package software.amazon.logs.loggroup;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 class Configuration extends BaseConfiguration {
 
@@ -16,6 +18,12 @@ class Configuration extends BaseConfiguration {
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
-        return null;
+        if (CollectionUtils.isNullOrEmpty(resourceModel.getTags())) {
+            return null;
+        }
+
+        return resourceModel.getTags()
+                .stream()
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
     }
 }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/CreateHandler.java
@@ -26,7 +26,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final ResourceModel model = request.getDesiredResourceState();
 
         try {
-            proxy.injectCredentialsAndInvokeV2(Translator.translateToCreateRequest(model),
+            proxy.injectCredentialsAndInvokeV2(Translator.translateToCreateRequest(model, request.getDesiredResourceTags()),
                 ClientBuilder.getClient()::createLogGroup);
         } catch (final ResourceAlreadyExistsException e) {
             throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME,

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ListHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ListHandler.java
@@ -1,11 +1,16 @@
 package software.amazon.logs.loggroup;
 
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ListHandler extends BaseHandler<CallbackContext> {
 
@@ -19,9 +24,17 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         final DescribeLogGroupsResponse response =
                 proxy.injectCredentialsAndInvokeV2(Translator.translateToListRequest(request.getNextToken()),
                     ClientBuilder.getClient()::describeLogGroups);
+
+        final Map<String, ListTagsLogGroupResponse> tagResponses = Translator.streamOfOrEmpty(response.logGroups())
+                .collect(Collectors.toMap(
+                        LogGroup::logGroupName,
+                        logGroup -> proxy.injectCredentialsAndInvokeV2(Translator.translateToListTagsLogGroupRequest(logGroup.logGroupName()),
+                                ClientBuilder.getClient()::listTagsLogGroup))
+                );
+
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .status(OperationStatus.SUCCESS)
-                .resourceModels(Translator.translateForList(response))
+                .resourceModels(Translator.translateForList(response, tagResponses))
                 .nextToken(response.nextToken())
                 .build();
     }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
@@ -13,8 +13,6 @@ import java.util.Objects;
 
 public class ReadHandler extends BaseHandler<CallbackContext> {
 
-    private static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
-
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -37,7 +35,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                 tagsResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToListTagsLogGroupRequest(model.getLogGroupName()),
                         ClientBuilder.getClient()::listTagsLogGroup);
             } catch (final CloudWatchLogsException e) {
-                if (ACCESS_DENIED_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
+                if (Translator.ACCESS_DENIED_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
                     // fail silently, if there is no permission to list tags
                     logger.log(e.getMessage());
                 } else {

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.logs.loggroup;
 
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -25,14 +26,17 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         }
 
         DescribeLogGroupsResponse response = null;
+        ListTagsLogGroupResponse tagsResponse = null;
         try {
             response = proxy.injectCredentialsAndInvokeV2(Translator.translateToReadRequest(model),
-                ClientBuilder.getClient()::describeLogGroups);
+                    ClientBuilder.getClient()::describeLogGroups);
+            tagsResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToListTagsLogGroupRequest(model.getLogGroupName()),
+                    ClientBuilder.getClient()::listTagsLogGroup);
         } catch (final ResourceNotFoundException e) {
             throwNotFoundException(model);
         }
 
-        final ResourceModel modelFromReadResult = Translator.translateForRead(response);
+        final ResourceModel modelFromReadResult = Translator.translateForRead(response, tagsResponse);
         if (modelFromReadResult.getLogGroupName() == null) {
             throwNotFoundException(model);
         }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -25,6 +25,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 final class Translator {
+
+    static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
+
     private Translator() {}
 
     static DescribeLogGroupsRequest translateToReadRequest(final ResourceModel model) {

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRe
 import software.amazon.awssdk.services.cloudwatchlogs.model.AssociateKmsKeyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.TagLogGroupRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.UntagLogGroupRequest;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -45,11 +46,11 @@ final class Translator {
                 .build();
     }
 
-    static CreateLogGroupRequest translateToCreateRequest(final ResourceModel model) {
+    static CreateLogGroupRequest translateToCreateRequest(final ResourceModel model, final Map<String, String> tags) {
         return CreateLogGroupRequest.builder()
                 .logGroupName(model.getLogGroupName())
                 .kmsKeyId(model.getKmsKeyId())
-                .tags(translateTagsToSdk(model.getTags()))
+                .tags(tags)
                 .build();
     }
 
@@ -85,10 +86,10 @@ final class Translator {
                 .build();
     }
 
-    static TagLogGroupRequest translateToTagLogGroupRequest(final String logGroupName, final Set<Tag> tags) {
+    static TagLogGroupRequest translateToTagLogGroupRequest(final String logGroupName, final Map<String, String> tags) {
         return TagLogGroupRequest.builder()
                 .logGroupName(logGroupName)
-                .tags(translateTagsToSdk(tags))
+                .tags(tags)
                 .build();
     }
 
@@ -163,14 +164,14 @@ final class Translator {
     }
 
     static Map<String, String> translateTagsToSdk(final Set<Tag> tags) {
-        if (tags == null || tags.isEmpty()) {
+        if (CollectionUtils.isNullOrEmpty(tags)) {
             return null;
         }
         return tags.stream().collect(Collectors.toMap(Tag::getKey, Tag::getValue));
     }
 
     static Set<Tag> translateSdkToTags(final Map<String, String> tags) {
-        if (tags == null || tags.isEmpty()) {
+        if (CollectionUtils.isNullOrEmpty(tags)) {
             return null;
         }
         return tags.entrySet().stream().map(tag -> new Tag(tag.getKey(), tag.getValue()))

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -120,7 +120,9 @@ final class Translator {
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElse(null);
-        final Set<Tag> tags = translateSdkToTags(tagsResponse.tags());
+        final Set<Tag> tags = translateSdkToTags(Optional.ofNullable(tagsResponse)
+                .map(ListTagsLogGroupResponse::tags)
+                .orElse(null));
         return ResourceModel.builder()
                 .arn(logGroupArn)
                 .logGroupName(logGroupName)

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
@@ -9,6 +9,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRequest;
@@ -201,6 +202,13 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             throwNotFoundException(model);
         } catch (final InvalidParameterException e) {
             throw new CfnInternalFailureException(e);
+        } catch (final CloudWatchLogsException e) {
+            if (Translator.ACCESS_DENIED_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
+                // fail silently, if there is no permission to list tags
+                logger.log(e.getMessage());
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/UpdateHandler.java
@@ -33,7 +33,6 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        // Everything except RetentionPolicyInDays, KmsKeyId and Tags is createOnly
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
         final boolean retentionChanged = ! retentionUnchanged(previousModel, model);
@@ -189,6 +188,8 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             }
         } catch (final ResourceNotFoundException e) {
             throwNotFoundException(model);
+        } catch (final InvalidParameterException e) {
+            throw new CfnInternalFailureException(e);
         }
     }
 

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ConfigurationTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ConfigurationTest.java
@@ -1,0 +1,28 @@
+package software.amazon.logs.loggroup;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationTest {
+
+    @Test
+    public void testResourceDefinedTags_MergeDuplicateKeys() {
+        final Set<Tag> tags = new HashSet<>(Arrays.asList(
+                Tag.builder().key("key-1").value("value-1").build(),
+                Tag.builder().key("key-1").value("value-2").build()
+        ));
+        final ResourceModel model = ResourceModel.builder()
+                .tags(tags)
+                .build();
+
+        final Configuration configuration = new Configuration();
+
+        assertThat(configuration.resourceDefinedTags(model)).isEqualTo(Collections.singletonMap("key-1", "value-2"));
+    }
+}

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ListHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ListHandlerTest.java
@@ -1,5 +1,6 @@
 package software.amazon.logs.loggroup;
 
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -15,6 +16,8 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRes
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -44,14 +47,28 @@ public class ListHandlerTest {
                 .retentionInDays(1)
                 .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
                 .build();
+        final Set<Tag> tags = new HashSet<>(Arrays.asList(
+                Tag.builder().key("key-1").value("value-1").build(),
+                Tag.builder().key("key-2").value("value-2").build()
+        ));
         final LogGroup logGroup2 = LogGroup.builder()
                 .logGroupName("LogGroup2")
                 .retentionInDays(2)
                 .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
                 .build();
+        final Set<Tag> tags2 = new HashSet<>(Arrays.asList(
+                Tag.builder().key("key-3").value("value-3").build(),
+                Tag.builder().key("key-4").value("value-4").build()
+        ));
         final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
                 .logGroups(Arrays.asList(logGroup, logGroup2))
                 .nextToken("token2")
+                .build();
+        final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
+                .tags(Translator.translateTagsToSdk(tags))
+                .build();
+        final ListTagsLogGroupResponse tagsResponse2 = ListTagsLogGroupResponse.builder()
+                .tags(Translator.translateTagsToSdk(tags2))
                 .build();
 
         doReturn(describeResponse)
@@ -60,17 +77,31 @@ public class ListHandlerTest {
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any()
             );
+        doReturn(tagsResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.eq(Translator.translateToListTagsLogGroupRequest(logGroup.logGroupName())),
+                        ArgumentMatchers.any()
+                );
+        doReturn(tagsResponse2)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.eq(Translator.translateToListTagsLogGroupRequest(logGroup2.logGroupName())),
+                        ArgumentMatchers.any()
+                );
 
         final ResourceModel model1 = ResourceModel.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
                 .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .tags(tags)
                 .build();
 
         final ResourceModel model2 = ResourceModel.builder()
                 .logGroupName("LogGroup2")
                 .retentionInDays(2)
                 .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+                .tags(tags2)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
@@ -1,5 +1,10 @@
 package software.amazon.logs.loggroup;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupResponse;
 import software.amazon.cloudformation.exceptions.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -22,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -166,5 +172,100 @@ public class ReadHandlerTest {
 
         assertThrows(ResourceNotFoundException.class,
             () -> handler.handleRequest(proxy, request, null, logger));
+    }
+
+    @Test
+    public void handleRequest_FailureListTagsAccessDenied_NoException() {
+        final LogGroup logGroup = LogGroup.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .build();
+        final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
+                .logGroups(Collections.singletonList(logGroup))
+                .build();
+
+        doReturn(describeResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.isA(DescribeLogGroupsRequest.class),
+                        ArgumentMatchers.any()
+                );
+        final AwsServiceException exception = CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDeniedException")
+                        .build())
+                .build();
+        doThrow(exception)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.isA(ListTagsLogGroupRequest.class),
+                        ArgumentMatchers.any()
+                );
+
+        final ResourceModel model = ResourceModel.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getResourceModel()).isEqualToComparingOnlyGivenFields(logGroup);
+        assertThat(response.getResourceModel().getTags()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailureListTags_WithException() {
+        final LogGroup logGroup = LogGroup.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .build();
+        final DescribeLogGroupsResponse describeResponse = DescribeLogGroupsResponse.builder()
+                .logGroups(Collections.singletonList(logGroup))
+                .build();
+
+        doReturn(describeResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.isA(DescribeLogGroupsRequest.class),
+                        ArgumentMatchers.any()
+                );
+        final AwsServiceException exception = CloudWatchLogsException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("InternalFailure")
+                        .build())
+                .build();
+        doThrow(exception)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(
+                        ArgumentMatchers.isA(ListTagsLogGroupRequest.class),
+                        ArgumentMatchers.any()
+                );
+
+        final ResourceModel model = ResourceModel.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        assertThrows(AwsServiceException.class,
+                () -> handler.handleRequest(proxy, request, null, logger));
     }
 }

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -79,7 +79,7 @@ public class TranslatorTest {
                 .kmsKeyId(RESOURCE_MODEL.getKmsKeyId())
                 .tags(MAP_TAGS)
                 .build();
-        assertThat(Translator.translateToCreateRequest(RESOURCE_MODEL)).isEqualToComparingFieldByField(request);
+        assertThat(Translator.translateToCreateRequest(RESOURCE_MODEL, MAP_TAGS)).isEqualToComparingFieldByField(request);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class TranslatorTest {
                 .tags(MAP_TAGS)
                 .build();
 
-        assertThat(Translator.translateToTagLogGroupRequest(RESOURCE_MODEL.getLogGroupName(), SET_TAGS))
+        assertThat(Translator.translateToTagLogGroupRequest(RESOURCE_MODEL.getLogGroupName(), MAP_TAGS))
                 .isEqualToComparingFieldByField(request);
     }
 

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -8,22 +8,44 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteLogGroupReques
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ListTagsLogGroupResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutRetentionPolicyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.AssociateKmsKeyRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.TagLogGroupRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.UntagLogGroupRequest;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 public class TranslatorTest {
+    private static final Set<Tag> SET_TAGS = new HashSet<>(Arrays.asList(
+            Tag.builder().key("key-1").value("value-1").build(),
+            Tag.builder().key("key-2").value("value-2").build()
+    ));
+
+    private static final Map<String, String> MAP_TAGS = new HashMap<String, String>() {{
+        put("key-1", "value-1");
+        put("key-2", "value-2");
+    }};
+
     private static final ResourceModel RESOURCE_MODEL = ResourceModel.builder()
-        .retentionInDays(1)
-        .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-        .logGroupName("LogGroup")
-        .build();
+            .retentionInDays(1)
+            .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            .logGroupName("LogGroup")
+            .tags(SET_TAGS)
+            .build();
 
     @Test
     public void testTranslateToRead() {
@@ -53,9 +75,10 @@ public class TranslatorTest {
     @Test
     public void testTranslateToCreate() {
         final CreateLogGroupRequest request = CreateLogGroupRequest.builder()
-            .logGroupName(RESOURCE_MODEL.getLogGroupName())
-            .kmsKeyId(RESOURCE_MODEL.getKmsKeyId())
-            .build();
+                .logGroupName(RESOURCE_MODEL.getLogGroupName())
+                .kmsKeyId(RESOURCE_MODEL.getKmsKeyId())
+                .tags(MAP_TAGS)
+                .build();
         assertThat(Translator.translateToCreateRequest(RESOURCE_MODEL)).isEqualToComparingFieldByField(request);
     }
 
@@ -102,6 +125,39 @@ public class TranslatorTest {
     }
 
     @Test
+    public void testTranslateToListTagsLogGroupRequest() {
+        final ListTagsLogGroupRequest request = ListTagsLogGroupRequest.builder()
+                .logGroupName(RESOURCE_MODEL.getLogGroupName())
+                .build();
+
+        assertThat(Translator.translateToListTagsLogGroupRequest(RESOURCE_MODEL.getLogGroupName()))
+                .isEqualToComparingFieldByField(request);
+    }
+
+    @Test
+    public void testTranslateToTagLogGroupRequest() {
+        final TagLogGroupRequest request = TagLogGroupRequest.builder()
+                .logGroupName(RESOURCE_MODEL.getLogGroupName())
+                .tags(MAP_TAGS)
+                .build();
+
+        assertThat(Translator.translateToTagLogGroupRequest(RESOURCE_MODEL.getLogGroupName(), SET_TAGS))
+                .isEqualToComparingFieldByField(request);
+    }
+
+    @Test
+    public void testTranslateToUntagLogGroupRequest() {
+        final List<String> tagKeys = SET_TAGS.stream().map(Tag::getKey).collect(Collectors.toList());
+        final UntagLogGroupRequest request = UntagLogGroupRequest.builder()
+                .logGroupName(RESOURCE_MODEL.getLogGroupName())
+                .tags(tagKeys)
+                .build();
+
+        assertThat(Translator.translateToUntagLogGroupRequest(RESOURCE_MODEL.getLogGroupName(), tagKeys))
+                .isEqualToComparingFieldByField(request);
+    }
+
+    @Test
     public void testTranslateForRead() {
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
@@ -112,7 +168,10 @@ public class TranslatorTest {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(logGroup))
                 .build();
-        assertThat(Translator.translateForRead(response)).isEqualToComparingFieldByField(RESOURCE_MODEL);
+        final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
+                .tags(MAP_TAGS)
+                .build();
+        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(RESOURCE_MODEL);
     }
 
     @Test
@@ -120,11 +179,15 @@ public class TranslatorTest {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
             .logGroups(Collections.emptyList())
             .build();
+        final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
+                .tags(Collections.emptyMap())
+                .build();
         final ResourceModel emptyModel = ResourceModel.builder()
                 .retentionInDays(null)
                 .logGroupName(null)
+                .tags(null)
                 .build();
-        assertThat(Translator.translateForRead(response)).isEqualToComparingFieldByField(emptyModel);
+        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test
@@ -132,11 +195,15 @@ public class TranslatorTest {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(LogGroup.builder().build()))
                 .build();
+        final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
+                .tags(Collections.emptyMap())
+                .build();
         final ResourceModel emptyModel = ResourceModel.builder()
-            .retentionInDays(null)
-            .logGroupName(null)
-            .build();
-        assertThat(Translator.translateForRead(response)).isEqualToComparingFieldByField(emptyModel);
+                .retentionInDays(null)
+                .logGroupName(null)
+                .tags(null)
+                .build();
+        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test
@@ -149,5 +216,27 @@ public class TranslatorTest {
     public void buildResourceDoesNotExistErrorMessage() {
         final String expected = "Resource of type 'AWS::Logs::LogGroup' with identifier 'ID' was not found.";
         assertThat(Translator.buildResourceDoesNotExistErrorMessage("ID")).isEqualTo(expected);
+    }
+
+    @Test
+    public void translateTagsToSdk() {
+        assertThat(Translator.translateTagsToSdk(SET_TAGS)).isEqualTo(MAP_TAGS);
+    }
+
+    @Test
+    public void translateTagsToSdk_TagsEmpty() {
+        assertThat(Translator.translateTagsToSdk(null)).isNull();
+        assertThat(Translator.translateTagsToSdk(Collections.emptySet())).isNull();
+    }
+
+    @Test
+    public void translateSdkToTags() {
+        assertThat(Translator.translateSdkToTags(MAP_TAGS)).isEqualTo(SET_TAGS);
+    }
+
+    @Test
+    public void translateSdkToTags_TagsEmpty() {
+        assertThat(Translator.translateSdkToTags(null)).isNull();
+        assertThat(Translator.translateSdkToTags(Collections.emptyMap())).isNull();
     }
 }

--- a/aws-logs-loggroup/template.yml
+++ b/aws-logs-loggroup/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::Logs::LogGroup resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
Fixes aws-cloudformation/aws-cloudformation-coverage-roadmap#77

*Description of changes:*
I added the possibility to add tags to the LogGroup resource. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
