### PR TITLE
add required field in JSON schema, change exception thrown for one failure case

### DIFF
--- a/aws-logs-querydefinition/aws-logs-querydefinition.json
+++ b/aws-logs-querydefinition/aws-logs-querydefinition.json
@@ -39,6 +39,10 @@
       "maxLength": 256
     }
   },
+  "required": [
+    "Name",
+    "QueryString"
+  ],
   "additionalProperties": false,
   "readOnlyProperties": [
     "/properties/QueryDefinitionId"

--- a/aws-logs-querydefinition/docs/README.md
+++ b/aws-logs-querydefinition/docs/README.md
@@ -36,7 +36,7 @@ Properties:
 
 A name for the saved query definition
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -52,7 +52,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The query string to use for this definition
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/aws-logs-querydefinition/src/main/java/software/amazon/logs/querydefinition/UpdateHandler.java
+++ b/aws-logs-querydefinition/src/main/java/software/amazon/logs/querydefinition/UpdateHandler.java
@@ -25,7 +25,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final ResourceModel model = request.getDesiredResourceState();
 
         if (model.getQueryDefinitionId() == null) {
-            return ProgressEvent.defaultFailureHandler(new CfnInvalidRequestException(ResourceModel.TYPE_NAME, new NullPointerException()), HandlerErrorCode.InvalidRequest);
+            return ProgressEvent.defaultFailureHandler(new CfnInvalidRequestException(ResourceModel.TYPE_NAME, new NullPointerException()), HandlerErrorCode.NotFound);
         }
 
         try {

--- a/aws-logs-querydefinition/src/test/java/software/amazon/logs/querydefinition/UpdateHandlerTest.java
+++ b/aws-logs-querydefinition/src/test/java/software/amazon/logs/querydefinition/UpdateHandlerTest.java
@@ -79,7 +79,7 @@ public class UpdateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a required field that is consistent with PutQueryDefinition API. This requires queryDef name, query string, and makes log group optional

Changes exception thrown when trying to update a non-existant resource from invalid request to not found as per CFN's contract testing requirements

*Testing* 

Unit Tests
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.964 s
[INFO] Finished at: 2021-03-22T10:59:20-07:00
[INFO] ------------------------------------------------------------------------
```

Contract tests:
```
===================================================================== 13 passed, 3 skipped, 8 warnings in 895.06s (0:14:55) ======================================================================
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
