### PR TITLE
Fix warnings from cfn validate

### DIFF
--- a/aws-logs-destination/aws-logs-destination.json
+++ b/aws-logs-destination/aws-logs-destination.json
@@ -74,5 +74,6 @@
   ],
   "primaryIdentifier": [
     "/properties/DestinationName"
-  ]
+  ],
+  "taggable": false
 }

--- a/aws-logs-metricfilter/aws-logs-metricfilter.json
+++ b/aws-logs-metricfilter/aws-logs-metricfilter.json
@@ -73,6 +73,7 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 1,
+      "insertionOrder": false,
       "items": {
         "$ref": "#/definitions/MetricTransformation"
       }
@@ -120,5 +121,6 @@
     "/properties/LogGroupName",
     "/properties/FilterName"
   ],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "taggable": false
 }

--- a/aws-logs-querydefinition/aws-logs-querydefinition.json
+++ b/aws-logs-querydefinition/aws-logs-querydefinition.json
@@ -27,6 +27,7 @@
     "LogGroupNames": {
       "description": "Optionally define specific log groups as part of your query definition",
       "type": "array",
+      "insertionOrder": false,
       "items": {
         "description": "LogGroup name",
         "$ref": "#/definitions/LogGroup"
@@ -76,5 +77,6 @@
         "logs:DescribeQueryDefinition"
       ]
     }
-  }
+  },
+  "taggable": false
 }

--- a/aws-logs-resourcepolicy/aws-logs-resourcepolicy.json
+++ b/aws-logs-resourcepolicy/aws-logs-resourcepolicy.json
@@ -19,6 +19,7 @@
     }
   },
   "additionalProperties": false,
+  "taggable": false,
   "primaryIdentifier": [
     "/properties/PolicyName"
   ],


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
When running `cfn validate` on the most recent version of `cloudformation-cli`, I would get the warning: `Explicitly specify value for taggable`. This change fixes that issue.

Specifying `"taggable": false` means the update handler for the resource won't be called when updating stack tags.
Specifying `"insertionOrder": false` means a change in the order of an array won't count as drift during drift detection tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
