### PR TITLE
Fixes Contract Test Errors for MetricFilter and Destination.

### DIFF
--- a/aws-logs-destination/dev-resources.yaml
+++ b/aws-logs-destination/dev-resources.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AWSServiceRoleForLogs:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: logs.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: logs_anything
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
+
+
+  KinesisStreamDestination:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: CanaryStream
+      ShardCount: 1
+
+Outputs:
+  KinesisStreamName:
+    Value: !GetAtt KinesisStreamDestination.Arn
+    Export:
+      Name: KinesisStreamForDestination
+
+  KinesisStreamRole:
+    Value: !GetAtt AWSServiceRoleForLogs.Arn
+    Export:
+      Name: KinesisStreamRoleForDestination
+
+  AccountArn:
+    Value: !Ref AWS::AccountId
+    Export:
+      Name: MyAWSAccountId

--- a/aws-logs-destination/overrides.json
+++ b/aws-logs-destination/overrides.json
@@ -1,0 +1,12 @@
+{
+  "CREATE": {
+    "/RoleArn": "{{KinesisStreamRoleForDestination}}",
+    "/TargetArn": "{{KinesisStreamForDestination}}",
+    "/DestinationPolicy": "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"AWS\":\"{{MyAWSAccountId}}\" }, \"Action\":\"*\", \"Resource\": \"*\" } ] }"
+  },
+  "UPDATE": {
+    "/RoleArn": "{{KinesisStreamRoleForDestination}}",
+    "/TargetArn": "{{KinesisStreamForDestination}}",
+    "/DestinationPolicy": "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"AWS\":\"{{MyAWSAccountId}}\" }, \"Action\":\"*\", \"Resource\": \"*\" } ] }"
+  }
+}

--- a/aws-logs-destination/pom.xml
+++ b/aws-logs-destination/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.13.18</version>
+            <version>2.15.19</version>
         </dependency>
     </dependencies>
 

--- a/aws-logs-destination/src/main/java/software/amazon/logs/destination/DeleteHandler.java
+++ b/aws-logs-destination/src/main/java/software/amazon/logs/destination/DeleteHandler.java
@@ -4,11 +4,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteDestinationRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteDestinationResponse;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.*;
 
 public class DeleteHandler extends BaseHandlerStd {
 
@@ -25,7 +21,7 @@ public class DeleteHandler extends BaseHandlerStd {
         return proxy.initiate("AWS-Logs-Destination::Delete", proxyClient, model, callbackContext)
                 .translateToServiceRequest(Translator::translateToDeleteRequest)
                 .makeServiceCall(this::deleteResource)
-                .success();
+                .done((x)-> ProgressEvent.<ResourceModel, CallbackContext>builder().status(OperationStatus.SUCCESS).build());
     }
 
     private DeleteDestinationResponse deleteResource(final DeleteDestinationRequest awsRequest,

--- a/aws-logs-destination/src/main/java/software/amazon/logs/destination/DeleteHandler.java
+++ b/aws-logs-destination/src/main/java/software/amazon/logs/destination/DeleteHandler.java
@@ -4,7 +4,12 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteDestinationRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteDestinationResponse;
-import software.amazon.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends BaseHandlerStd {
 

--- a/aws-logs-destination/src/test/java/software/amazon/logs/destination/DeleteHandlerTest.java
+++ b/aws-logs-destination/src/test/java/software/amazon/logs/destination/DeleteHandlerTest.java
@@ -73,7 +73,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/aws-logs-destination/template.yml
+++ b/aws-logs-destination/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::Logs::Destination resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 512
 
 Resources:
   TypeFunction:

--- a/aws-logs-metricfilter/dev-resources.yaml
+++ b/aws-logs-metricfilter/dev-resources.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ContractTestLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: "this-is-a-random-loggroup"

--- a/aws-logs-metricfilter/overrides.json
+++ b/aws-logs-metricfilter/overrides.json
@@ -5,7 +5,7 @@
     "/FilterPattern": "[size]",
     "/MetricTransformations": [
       {
-        "MetricValue": 10,
+        "MetricValue": "10",
         "MetricNamespace": "my-namespace",
         "MetricName": "metric-name"
       }

--- a/aws-logs-metricfilter/pom.xml
+++ b/aws-logs-metricfilter/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.13.18</version>
+            <version>2.15.19</version>
         </dependency>
     </dependencies>
 

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
@@ -2,10 +2,23 @@ package software.amazon.logs.metricfilter;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
-import software.amazon.awssdk.services.cloudwatchlogs.model.*;
-import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.*;
-import software.amazon.cloudformation.proxy.*;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LimitExceededException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.OperationAbortedException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutMetricFilterRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutMetricFilterResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ServiceUnavailableException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
 public class CreateHandler extends BaseHandlerStd {

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/CreateHandler.java
@@ -5,12 +5,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.*;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
 import software.amazon.cloudformation.exceptions.*;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.*;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
 public class CreateHandler extends BaseHandlerStd {
@@ -36,7 +31,8 @@ public class CreateHandler extends BaseHandlerStd {
         return proxy.initiate("AWS-Logs-MetricFilter::Create", proxyClient, model, callbackContext)
                 .translateToServiceRequest(Translator::translateToCreateRequest)
                 .makeServiceCall((r, c) -> createResource(model, r, c))
-                .success();
+                .success().then((x)-> ProgressEvent.<ResourceModel, CallbackContext>builder().resourceModel(model).status(OperationStatus.SUCCESS).build());
+
     }
 
     private PutMetricFilterResponse createResource(

--- a/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/DeleteHandler.java
+++ b/aws-logs-metricfilter/src/main/java/software/amazon/logs/metricfilter/DeleteHandler.java
@@ -39,7 +39,6 @@ public class DeleteHandler extends BaseHandlerStd {
                 .makeServiceCall(this::deleteResource)
                 .done(awsResponse -> ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .status(OperationStatus.SUCCESS)
-                    .resourceModel(model)
                     .build());
     }
 

--- a/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/DeleteHandlerTest.java
+++ b/aws-logs-metricfilter/src/test/java/software/amazon/logs/metricfilter/DeleteHandlerTest.java
@@ -75,7 +75,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/aws-logs-metricfilter/template.yml
+++ b/aws-logs-metricfilter/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::Logs::MetricFilter resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 512
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
 Fixes Contract Test Errors for MetricFilter and Destination.

Destination changes are to fix the `AssertionError: The deletion handler's response object MUST NOT contain a model` error

MetricFilter changes are to fix the same error as above as well as `AssertionError: All properties specified in the request MUST be present in the model returned, and they MUST match exactly, with the exception of properties defined as writeOnlyProperties in the resource schema
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
