### PR TITLE
Fix ReadHandler to use resource policy info from DescribeResourcePolicies request

### DIFF
--- a/aws-logs-resourcepolicy/src/main/java/software/amazon/logs/resourcepolicy/ReadHandler.java
+++ b/aws-logs-resourcepolicy/src/main/java/software/amazon/logs/resourcepolicy/ReadHandler.java
@@ -37,8 +37,9 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                         .filter(rp -> rp.policyName().equals(model.getPolicyName()))
                         .findAny();
                 if (resourcePolicy.isPresent()) {
+                    ResourcePolicy outputPolicy = resourcePolicy.get();
                     return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                            .resourceModel(model)
+                            .resourceModel(ResourceModel.builder().policyDocument(outputPolicy.policyDocument()).policyName(outputPolicy.policyName()).build())
                             .status(OperationStatus.SUCCESS)
                             .build();
                 }


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
This changes the resource policy read handler to use the actual data it receives from the DescribeResourcePolicies request instead of the ResourceModel it received to search with.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
