### PR TITLE
Fix read handler to match exact log group name instead of prefix

### DIFF
--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
@@ -52,7 +52,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                 throwNotFoundException(model);
             }
 
-            modelFromReadResult = Translator.translateForRead(response, tagsResponse, model.getLogGroupName());
+            modelFromReadResult = Translator.translateForReadResponse(response, tagsResponse, model.getLogGroupName());
 
             // If log group found, break out of loop
             if (modelFromReadResult.getLogGroupName() != null) {

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ReadHandler.java
@@ -8,6 +8,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 
 import java.util.Objects;
 
@@ -27,35 +28,21 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         }
 
         DescribeLogGroupsResponse response = null;
-        ListTagsLogGroupResponse tagsResponse = null;
-        ResourceModel modelFromReadResult = null;
+        LogGroup matchingLogGroup = null;
         String nextToken = null;
         // Keep paginating until requested log group is found
         do {
             try {
                 response = proxy.injectCredentialsAndInvokeV2(Translator.translateToReadRequest(model, nextToken),
                         ClientBuilder.getClient()::describeLogGroups);
-                if (tagsResponse == null) {
-                    try {
-                        tagsResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToListTagsLogGroupRequest(model.getLogGroupName()),
-                                ClientBuilder.getClient()::listTagsLogGroup);
-                    } catch (final CloudWatchLogsException e) {
-                        if (Translator.ACCESS_DENIED_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
-                            // fail silently, if there is no permission to list tags
-                            logger.log(e.getMessage());
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
             } catch (final ResourceNotFoundException e) {
                 throwNotFoundException(model);
             }
 
-            modelFromReadResult = Translator.translateForReadResponse(response, tagsResponse, model.getLogGroupName());
+            matchingLogGroup = Translator.getMatchingLogGroup(response, model.getLogGroupName());
 
             // If log group found, break out of loop
-            if (modelFromReadResult.getLogGroupName() != null) {
+            if (matchingLogGroup != null) {
                 break;
             }
 
@@ -63,9 +50,24 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         } while (nextToken != null);
 
         // If paginated all log groups, still cannot find it
-        if (modelFromReadResult.getLogGroupName() == null) {
+        if (matchingLogGroup == null) {
             throwNotFoundException(model);
         }
+
+        ListTagsLogGroupResponse tagsResponse = null;
+        try {
+            tagsResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToListTagsLogGroupRequest(model.getLogGroupName()),
+                    ClientBuilder.getClient()::listTagsLogGroup);
+        } catch (final CloudWatchLogsException e) {
+            if (Translator.ACCESS_DENIED_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
+                // fail silently, if there is no permission to list tags
+                logger.log(e.getMessage());
+            } else {
+                throw e;
+            }
+        }
+
+        ResourceModel modelFromReadResult = Translator.translateForReadResponse(matchingLogGroup, tagsResponse);
 
         return ProgressEvent.defaultSuccessHandler(modelFromReadResult);
     }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -117,7 +117,7 @@ final class Translator {
     static ResourceModel translateForReadResponse(final DescribeLogGroupsResponse response, final ListTagsLogGroupResponse tagsResponse, final String requestLogGroupName) {
         LogGroup matchedLogGroup = streamOfOrEmpty(response.logGroups())
                 .filter(Objects::nonNull)
-                .filter(logGroup -> logGroup.logGroupName() != null && logGroup.logGroupName().equals(requestLogGroupName))
+                .filter(lg -> lg.logGroupName().equals(requestLogGroupName))
                 .findAny()
                 .orElse(null);
         final Set<Tag> tags = translateSdkToTags(Optional.ofNullable(tagsResponse)

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.DisassociateKmsKeyRe
 import software.amazon.awssdk.services.cloudwatchlogs.model.AssociateKmsKeyRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.TagLogGroupRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.UntagLogGroupRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 import java.util.Collection;
@@ -30,9 +31,10 @@ final class Translator {
 
     private Translator() {}
 
-    static DescribeLogGroupsRequest translateToReadRequest(final ResourceModel model) {
+    static DescribeLogGroupsRequest translateToReadRequest(final ResourceModel model, final String nextToken) {
         return DescribeLogGroupsRequest.builder()
                 .logGroupNamePrefix(model.getLogGroupName())
+                .nextToken(nextToken)
                 .build();
     }
 
@@ -111,35 +113,22 @@ final class Translator {
                 .build();
     }
 
-    static ResourceModel translateForRead(final DescribeLogGroupsResponse response, final ListTagsLogGroupResponse tagsResponse) {
-        final String logGroupName = streamOfOrEmpty(response.logGroups())
-                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::logGroupName)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
-        final String logGroupArn = streamOfOrEmpty(response.logGroups())
-                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::arn)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
-        final Integer retentionInDays = streamOfOrEmpty(response.logGroups())
-                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::retentionInDays)
-                .filter(Objects::nonNull)
-                .findAny()
-                .orElse(null);
-        final String kmsKeyId = streamOfOrEmpty(response.logGroups())
-                .map(software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup::kmsKeyId)
-                .filter(Objects::nonNull)
+    static ResourceModel translateForRead(final DescribeLogGroupsResponse response, final ListTagsLogGroupResponse tagsResponse, final String requestLogGroupName) {
+        LogGroup matchedLogGroup = streamOfOrEmpty(response.logGroups())
+                .filter(logGroup -> logGroup.logGroupName() != null && logGroup.logGroupName().equals(requestLogGroupName))
                 .findAny()
                 .orElse(null);
         final Set<Tag> tags = translateSdkToTags(Optional.ofNullable(tagsResponse)
                 .map(ListTagsLogGroupResponse::tags)
                 .orElse(null));
+        if (matchedLogGroup == null) return ResourceModel.builder()
+                .tags(tags)
+                .build();
         return ResourceModel.builder()
-                .arn(logGroupArn)
-                .logGroupName(logGroupName)
-                .retentionInDays(retentionInDays)
-                .kmsKeyId(kmsKeyId)
+                .arn(matchedLogGroup.arn())
+                .logGroupName(matchedLogGroup.logGroupName())
+                .retentionInDays(matchedLogGroup.retentionInDays())
+                .kmsKeyId(matchedLogGroup.kmsKeyId())
                 .tags(tags)
                 .build();
     }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/Translator.java
@@ -113,17 +113,17 @@ final class Translator {
                 .build();
     }
 
-    static ResourceModel translateForRead(final DescribeLogGroupsResponse response, final ListTagsLogGroupResponse tagsResponse, final String requestLogGroupName) {
+    // Translates for the read response that is retrieved
+    static ResourceModel translateForReadResponse(final DescribeLogGroupsResponse response, final ListTagsLogGroupResponse tagsResponse, final String requestLogGroupName) {
         LogGroup matchedLogGroup = streamOfOrEmpty(response.logGroups())
+                .filter(Objects::nonNull)
                 .filter(logGroup -> logGroup.logGroupName() != null && logGroup.logGroupName().equals(requestLogGroupName))
                 .findAny()
                 .orElse(null);
         final Set<Tag> tags = translateSdkToTags(Optional.ofNullable(tagsResponse)
                 .map(ListTagsLogGroupResponse::tags)
                 .orElse(null));
-        if (matchedLogGroup == null) return ResourceModel.builder()
-                .tags(tags)
-                .build();
+        if (matchedLogGroup == null) return ResourceModel.builder().build();
         return ResourceModel.builder()
                 .arn(matchedLogGroup.arn())
                 .logGroupName(matchedLogGroup.logGroupName())

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/ReadHandlerTest.java
@@ -125,7 +125,7 @@ public class ReadHandlerTest {
                 .tags(Translator.translateTagsToSdk(tags))
                 .build();
 
-        doReturn(describeResponse1, tagsResponse, describeResponse2, tagsResponse)
+        doReturn(describeResponse1, describeResponse2, tagsResponse)
                 .when(proxy)
                 .injectCredentialsAndInvokeV2(
                         ArgumentMatchers.any(),

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -214,14 +214,14 @@ public class TranslatorTest {
     @Test
     public void testTranslateForReadResponse_LogGroupHasNullMembers() {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
-                .logGroups(Collections.singletonList(LogGroup.builder().build()))
+                .logGroups(Collections.singletonList(LogGroup.builder().logGroupName("LogGroup").build()))
                 .build();
         final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
                 .tags(Collections.emptyMap())
                 .build();
         final ResourceModel emptyModel = ResourceModel.builder()
                 .retentionInDays(null)
-                .logGroupName(null)
+                .logGroupName("LogGroup")
                 .tags(null)
                 .build();
         assertThat(Translator.translateForReadResponse(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -158,7 +158,7 @@ public class TranslatorTest {
     }
 
     @Test
-    public void testTranslateForRead() {
+    public void testTranslateForReadResponse() {
         final LogGroup logGroup = LogGroup.builder()
             .logGroupName("LogGroup")
             .retentionInDays(1)
@@ -171,11 +171,11 @@ public class TranslatorTest {
         final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
                 .tags(MAP_TAGS)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
+        assertThat(Translator.translateForReadResponse(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
     }
 
     @Test
-    public void testTranslateForRead_ExactLogGroupName() {
+    public void testTranslateForReadResponse_ExactLogGroupName() {
         final LogGroup logGroup = LogGroup.builder()
                 .logGroupName("LogGroup")
                 .retentionInDays(1)
@@ -192,11 +192,11 @@ public class TranslatorTest {
         final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
                 .tags(MAP_TAGS)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
+        assertThat(Translator.translateForReadResponse(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
     }
 
     @Test
-    public void testTranslateForRead_logGroupEmpty() {
+    public void testTranslateForReadResponse_logGroupEmpty() {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
             .logGroups(Collections.emptyList())
             .build();
@@ -208,11 +208,11 @@ public class TranslatorTest {
                 .logGroupName(null)
                 .tags(null)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
+        assertThat(Translator.translateForReadResponse(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test
-    public void testTranslateForRead_LogGroupHasNullMembers() {
+    public void testTranslateForReadResponse_LogGroupHasNullMembers() {
         final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
                 .logGroups(Collections.singletonList(LogGroup.builder().build()))
                 .build();
@@ -224,7 +224,7 @@ public class TranslatorTest {
                 .logGroupName(null)
                 .tags(null)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
+        assertThat(Translator.translateForReadResponse(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test

--- a/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
+++ b/aws-logs-loggroup/src/test/java/software/amazon/logs/loggroup/TranslatorTest.java
@@ -52,7 +52,7 @@ public class TranslatorTest {
         final DescribeLogGroupsRequest request = DescribeLogGroupsRequest.builder()
             .logGroupNamePrefix(RESOURCE_MODEL.getLogGroupName())
             .build();
-        assertThat(Translator.translateToReadRequest(RESOURCE_MODEL)).isEqualToComparingFieldByField(request);
+        assertThat(Translator.translateToReadRequest(RESOURCE_MODEL, null)).isEqualToComparingFieldByField(request);
     }
 
     @Test
@@ -171,7 +171,28 @@ public class TranslatorTest {
         final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
                 .tags(MAP_TAGS)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(RESOURCE_MODEL);
+        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
+    }
+
+    @Test
+    public void testTranslateForRead_ExactLogGroupName() {
+        final LogGroup logGroup = LogGroup.builder()
+                .logGroupName("LogGroup")
+                .retentionInDays(1)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .build();
+        final LogGroup logGroup2 = LogGroup.builder()
+                .logGroupName("LogGroup2")
+                .retentionInDays(2)
+                .kmsKeyId("arn:aws:kms:us-east-1:$123456789012:key/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+                .build();
+        final DescribeLogGroupsResponse response = DescribeLogGroupsResponse.builder()
+                .logGroups(Arrays.asList(logGroup2, logGroup))
+                .build();
+        final ListTagsLogGroupResponse tagsResponse = ListTagsLogGroupResponse.builder()
+                .tags(MAP_TAGS)
+                .build();
+        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(RESOURCE_MODEL);
     }
 
     @Test
@@ -187,7 +208,7 @@ public class TranslatorTest {
                 .logGroupName(null)
                 .tags(null)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(emptyModel);
+        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test
@@ -203,7 +224,7 @@ public class TranslatorTest {
                 .logGroupName(null)
                 .tags(null)
                 .build();
-        assertThat(Translator.translateForRead(response, tagsResponse)).isEqualToComparingFieldByField(emptyModel);
+        assertThat(Translator.translateForRead(response, tagsResponse, "LogGroup")).isEqualToComparingFieldByField(emptyModel);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
Changed read handler logic such that it now filters through the response log groups and returns a log group that matches the entire log group name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
