### PR TITLE
update LogGroup tagging impl and fix stack tag propagation

### DIFF
--- a/aws-logs-loggroup/aws-logs-loggroup.json
+++ b/aws-logs-loggroup/aws-logs-loggroup.json
@@ -127,5 +127,7 @@
     "/properties/LogGroupName"
   ],
   "additionalProperties": false,
-  "taggable": true
+  "tagging": {
+    "taggable": true
+  }
 }

--- a/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/TagHelper.java
+++ b/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/TagHelper.java
@@ -1,0 +1,163 @@
+package software.amazon.logs.loggroup;
+import software.amazon.logs.loggroup.Tag;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.SdkClient;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class TagHelper {
+    /**
+     * convertToMap
+     *
+     * Converts a collection of Tag objects to a tag-name -> tag-value map.
+     *
+     * Note: Tag objects with null tag values will not be included in the output
+     * map.
+     *
+     * @param tags Collection of tags to convert
+     * @return Converted Map of tags
+     */
+    public static Map<String, String> convertToMap(final Collection<Tag> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyMap();
+        }
+        return tags.stream()
+            .filter(tag -> tag.getValue() != null)
+            .collect(Collectors.toMap(
+                Tag::getKey,
+                Tag::getValue,
+                (oldValue, newValue) -> newValue));
+    }
+
+    /**
+     * convertToSet
+     *
+     * Converts a tag map to a set of Tag objects.
+     *
+     * Note: Like convertToMap, convertToSet filters out value-less tag entries.
+     *
+     * @param tagMap Map of tags to convert
+     * @return Set of Tag objects
+     */
+    public static Set<Tag> convertToSet(final Map<String, String> tagMap) {
+        if (MapUtils.isEmpty(tagMap)) {
+            return Collections.emptySet();
+        }
+        return tagMap.entrySet().stream()
+            .filter(tag -> tag.getValue() != null)
+            .map(tag -> Tag.builder()
+                .key(tag.getKey())
+                .value(tag.getValue())
+                .build())
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * generateTagsForCreate
+     *
+     * Generate tags to put into resource creation request.
+     * This includes user defined tags and system tags as well.
+     */
+    public final Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> tagMap = new HashMap<>();
+
+        // merge system tags with desired resource tags if your service supports CloudFormation system tags
+        tagMap.putAll(handlerRequest.getSystemTags());
+
+        if (handlerRequest.getDesiredResourceTags() != null) {
+            tagMap.putAll(handlerRequest.getDesiredResourceTags());
+        }
+
+        // TODO: get tags from resource model based on your tag property name
+        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
+        return Collections.unmodifiableMap(tagMap);
+    }
+
+    /**
+     * shouldUpdateTags
+     *
+     * Determines whether user defined tags have been changed during update.
+     */
+    public static final boolean shouldUpdateTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> previousTags = getPreviouslyAttachedTags(handlerRequest);
+        final Map<String, String> desiredTags = getNewDesiredTags(resourceModel, handlerRequest);
+        return ObjectUtils.notEqual(previousTags, desiredTags);
+    }
+
+    /**
+     * getPreviouslyAttachedTags
+     *
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get previous attached user defined tags from both handlerRequest.getPreviousResourceTags (stack tags)
+     * and handlerRequest.getPreviousResourceState (resource tags).
+     */
+    public static Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        // get previous stack level tags from handlerRequest
+        final Map<String, String> previousTags = handlerRequest.getPreviousResourceTags() != null ?
+            handlerRequest.getPreviousResourceTags() : Collections.emptyMap();
+
+        // TODO: get resource level tags from previous resource state based on your tag property name
+        // TODO: previousTags.putAll(handlerRequest.getPreviousResourceState().getTags());
+        return previousTags;
+    }
+
+    /**
+     * getNewDesiredTags
+     *
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get new user defined tags from both resource model and previous stack tags.
+     */
+    public static Map<String, String> getNewDesiredTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        // get new stack level tags from handlerRequest
+        final Map<String, String> desiredTags = handlerRequest.getDesiredResourceTags() != null ?
+            handlerRequest.getDesiredResourceTags() : Collections.emptyMap();
+
+        // TODO: get resource level tags from resource model based on your tag property name
+        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags()));
+        return desiredTags;
+    }
+
+    /**
+     * generateTagsToAdd
+     *
+     * Determines the tags the customer desired to define or redefine.
+     */
+    public static Map<String, String> generateTagsToAdd(final Map<String, String> previousTags, final Map<String, String> desiredTags) {
+        return desiredTags.entrySet().stream()
+            .filter(e -> !previousTags.containsKey(e.getKey()) || !Objects.equals(previousTags.get(e.getKey()), e.getValue()))
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue));
+    }
+
+    /**
+     * getTagsToRemove
+     *
+     * Determines the tags the customer desired to remove from the function.
+     */
+    public static Set<String> generateTagsToRemove(final Map<String, String> previousTags, final Map<String, String> desiredTags) {
+        final Set<String> desiredTagNames = desiredTags.keySet();
+
+        return previousTags.keySet().stream()
+            .filter(tagName -> !desiredTagNames.contains(tagName))
+            .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
*Issue #:* Based on [#919](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/919)

*Description of changes:*
Updated tagging implementation to align with CloudFormation best practices and fix an issue where stack tags did not propagate to AWS::Logs::LogGroup resource during update.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
