### PR TITLE
[Logs-destination] destinationaName filter

### DIFF
--- a/aws-logs-destination/src/main/java/software/amazon/logs/destination/BaseHandlerStd.java
+++ b/aws-logs-destination/src/main/java/software/amazon/logs/destination/BaseHandlerStd.java
@@ -61,9 +61,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 });
     }
 
-    protected boolean isDestinationListNullOrEmpty(final DescribeDestinationsResponse response) {
-        return ! response.hasDestinations() || response.destinations()
-                .isEmpty();
+    protected boolean isDestinationExists(final DescribeDestinationsResponse response, final ResourceModel model){
+        if (response.destinations().isEmpty()) {
+            return false;
+        }
+        return model.getDestinationName().equals(response.destinations().get(0).destinationName());
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> putDestination(final AmazonWebServicesClientProxy proxy,

--- a/aws-logs-destination/src/main/java/software/amazon/logs/destination/CreateHandler.java
+++ b/aws-logs-destination/src/main/java/software/amazon/logs/destination/CreateHandler.java
@@ -28,7 +28,7 @@ public class CreateHandler extends BaseHandlerStd {
         // Create destination policy command checks to see if optional destination/access policy is passed in before attempting create
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> preCreateCheck(proxy, callbackContext, proxyClient, model).done((response) -> {
-                    if (isDestinationListNullOrEmpty(response)) {
+                    if (!isDestinationExists(response, model)) {
                         return ProgressEvent.progress(model, callbackContext);
                     }
                     return ProgressEvent.defaultFailureHandler(new CfnAlreadyExistsException(ResourceModel.TYPE_NAME,

--- a/aws-logs-destination/src/main/java/software/amazon/logs/destination/UpdateHandler.java
+++ b/aws-logs-destination/src/main/java/software/amazon/logs/destination/UpdateHandler.java
@@ -25,7 +25,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> preCreateCheck(proxy, callbackContext, proxyClient, model).done((response) -> {
-                    if (isDestinationListNullOrEmpty(response)) {
+                    if (!isDestinationExists(response, model)) {
                         return ProgressEvent.defaultFailureHandler(new CfnNotFoundException(ResourceModel.TYPE_NAME,
                                 model.getPrimaryIdentifier()
                                         .toString()), HandlerErrorCode.NotFound);


### PR DESCRIPTION
This PR fix the behaviour of the AWS::Logs::Destination that returns that a destination already exists just if the desired name is a prefix of the existing name 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
