### PR TITLE
add missing handler permissions

### DIFF
--- a/aws-logs-destination/aws-logs-destination.json
+++ b/aws-logs-destination/aws-logs-destination.json
@@ -37,6 +37,7 @@
       "permissions": [
         "logs:PutDestination",
         "logs:PutDestinationPolicy",
+        "logs:DescribeDestinations",
         "iam:PassRole"
       ]
     },
@@ -48,7 +49,9 @@
     "update": {
       "permissions": [
         "logs:PutDestination",
-        "logs:PutDestinationPolicy"
+        "logs:PutDestinationPolicy",
+        "logs:DescribeDestinations",
+        "iam:PassRole"
       ]
     },
     "delete": {

--- a/aws-logs-subscriptionfilter/aws-logs-subscriptionfilter.json
+++ b/aws-logs-subscriptionfilter/aws-logs-subscriptionfilter.json
@@ -67,7 +67,17 @@
     "list": {
       "permissions": [
         "logs:DescribeSubscriptionFilters"
-      ]
+      ],
+      "handlerSchema": {
+        "properties": {
+          "LogGroupName": {
+            "$ref": "resource-schema.json#/properties/LogGroupName"
+          }
+        },
+        "required": [
+          "LogGroupName"
+        ]
+      }
     }
   },
   "required": [


### PR DESCRIPTION
*Description of changes:*
This change adds missing permissions to the `AWS::Logs::Destination` and `AWS::Logs::SubscriptionFilter` handlers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
